### PR TITLE
impl Clone + Debug for core types + VariantDispatch

### DIFF
--- a/gdnative-core/src/core_types/dictionary.rs
+++ b/gdnative-core/src/core_types/dictionary.rs
@@ -544,6 +544,12 @@ where
     }
 }
 
+impl Clone for Dictionary {
+    fn clone(&self) -> Self {
+        self.new_ref()
+    }
+}
+
 godot_test!(test_dictionary {
     use std::collections::HashSet;
 

--- a/gdnative-core/src/core_types/node_path.rs
+++ b/gdnative-core/src/core_types/node_path.rs
@@ -176,3 +176,10 @@ impl fmt::Debug for NodePath {
         write!(f, "NodePath({})", self.to_string())
     }
 }
+
+impl Clone for NodePath {
+    #[inline]
+    fn clone(&self) -> Self {
+        self.new_ref()
+    }
+}

--- a/gdnative-core/src/core_types/rect2.rs
+++ b/gdnative-core/src/core_types/rect2.rs
@@ -1,5 +1,6 @@
 use super::Vector2;
 
+#[derive(Copy, Clone, Debug, PartialEq)]
 #[repr(C)]
 pub struct Rect2 {
     pub position: Vector2,

--- a/gdnative-core/src/core_types/transform2d.rs
+++ b/gdnative-core/src/core_types/transform2d.rs
@@ -1,5 +1,6 @@
 use super::Vector2;
 
+#[derive(Copy, Clone, Debug, PartialEq)]
 #[repr(C)]
 pub struct Transform2D {
     pub x: Vector2,

--- a/gdnative-core/src/core_types/variant.rs
+++ b/gdnative-core/src/core_types/variant.rs
@@ -113,6 +113,7 @@ macro_rules! decl_variant_type {
         ///
         /// For `Variant`s containing objects, the original `Variant` is returned unchanged, due to
         /// the limitations of statically-determined memory management.
+        #[derive(Clone, Debug)]
         #[repr(u32)]
         pub enum VariantDispatch {
             $(

--- a/gdnative-core/src/core_types/variant_array.rs
+++ b/gdnative-core/src/core_types/variant_array.rs
@@ -588,6 +588,12 @@ impl<T: ToVariant, Access: LocalThreadAccess> Extend<T> for VariantArray<Access>
     }
 }
 
+impl Clone for VariantArray {
+    fn clone(&self) -> Self {
+        self.new_ref()
+    }
+}
+
 godot_test!(test_array {
     let foo = Variant::from_str("foo");
     let bar = Variant::from_str("bar");


### PR DESCRIPTION
This implements `Clone` and `Debug` for all core types and for `VariantDispatch`. For types that implement `NewRef`, `Clone` was implemented in terms of it. Types that could derive `Copy` do so.