### PR TITLE
Fix clippy lints in nightly

### DIFF
--- a/bindings_generator/src/classes.rs
+++ b/bindings_generator/src/classes.rs
@@ -12,10 +12,12 @@ use std::collections::HashMap;
 pub(crate) fn generate_class_struct(class: &GodotClass) -> TokenStream {
     let class_name = format_ident!("{}", &class.name);
 
+    // dead_code: 'this' might not be read
     quote! {
         #[allow(non_camel_case_types)]
         #[derive(Debug)]
         pub struct #class_name {
+            #[allow(dead_code)]
             this: RawObject<Self>,
         }
     }

--- a/gdnative-core/src/core_types/dictionary.rs
+++ b/gdnative-core/src/core_types/dictionary.rs
@@ -625,9 +625,11 @@ godot_test!(test_dictionary {
     let expected_keys = ["foo", "bar"].iter().map(|&s| s.to_string()).collect::<HashSet<_>>();
     for (key, value) in &dict {
         assert_eq!(Some(value), dict.get(&key));
-        if !iter_keys.insert(key.to_string()) {
-            panic!("key is already contained in set: {:?}", key);
-        }
+        assert!(
+            iter_keys.insert(key.to_string()) ,
+            "key is already contained in set: {:?}",
+            key
+        );
     }
     assert_eq!(expected_keys, iter_keys);
 });

--- a/gdnative-core/src/lib.rs
+++ b/gdnative-core/src/lib.rs
@@ -20,7 +20,11 @@
 //! [thread-safety]: https://docs.godotengine.org/en/stable/tutorials/threads/thread_safe_apis.html
 
 #![deny(clippy::missing_inline_in_public_items)]
-#![allow(clippy::transmute_ptr_to_ptr)]
+#![allow(
+    clippy::transmute_ptr_to_ptr,
+    clippy::missing_safety_doc,
+    clippy::if_then_panic
+)]
 #![cfg_attr(feature = "gd_test", allow(clippy::blacklisted_name))]
 
 #[doc(hidden)]

--- a/gdnative-core/src/private.rs
+++ b/gdnative-core/src/private.rs
@@ -79,6 +79,7 @@ unsafe fn check_api_compatibility(
 /// not bound will lead to an abort**, since in most cases there is simply no point to continue
 /// if `get_api` failed. This allows it to be used in FFI contexts without a `catch_unwind`.
 #[inline]
+#[allow(clippy::redundant_closure)] // clippy false positive: https://github.com/rust-lang/rust-clippy/issues/7812
 pub fn get_api() -> &'static sys::GodotApi {
     unsafe { GODOT_API.as_ref().unwrap_or_else(|| std::process::abort()) }
 }

--- a/gdnative-sys/build.rs
+++ b/gdnative-sys/build.rs
@@ -64,9 +64,10 @@ mod header_binding {
         // and have been erroneously used for target platforms in this library in the past. Make sure
         // to double-check them wherever they occur.
 
-        if !cfg!(target_arch = "x86_64") {
-            panic!("unsupported host architecture: build from x86_64 instead");
-        }
+        assert!(
+            cfg!(target_arch = "x86_64"),
+            "unsupported host architecture: build from x86_64 instead"
+        );
 
         builder = builder
             .clang_arg("-I")
@@ -457,9 +458,10 @@ mod api_wrapper {
 
         for api in api_root.all_apis() {
             // Currently don't support Godot 4.0
-            if api.version.major == 1 && api.version.minor == 3 {
-                panic!("GodotEngine v4.* is not yet supported. See https://github.com/godot-rust/godot-rust/issues/396");
-            }
+            assert!(
+                !(api.version.major == 1 && api.version.minor == 3),
+                "GodotEngine v4.* is not yet supported. See https://github.com/godot-rust/godot-rust/issues/396"
+            );
         }
 
         let struct_fields = godot_api_functions(&api_root);

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::blacklisted_name)]
+#![allow(clippy::blacklisted_name, clippy::if_then_panic)]
 
 use gdnative::prelude::*;
 


### PR DESCRIPTION
Where "fix" means mostly "disable".

Lints turned off globally for the time being (might change in the future):
* `clippy::missing_safety_doc` -- requires each unsafe fn/trait to have a `# Safety` section.
   Nice in theory, annoying for internals, and boilerplate-enforcing for obvious public cases.
* `clippy::if_then_panic` -- suggests that `if (!cond) { panic!(msg); }` be written as `assert!(cond, msg);`
   Probably makes sense to enable later, but currently not possible due to [approx/#73](https://github.com/brendanzab/approx/issues/73).

Lints turned of locally:
* `clippy::redundant_closure` -- works around false positive [rust-clippy/#7812](https://github.com/rust-lang/rust-clippy/issues/7812)
* `dead_code` (compiler warning, not clippy) -- generated field `this` not always used. Naming it `_this` doesn't seem right, either.