### PR TITLE
Re-export `gdnative_core::log` again

### DIFF
--- a/gdnative-core/src/lib.rs
+++ b/gdnative-core/src/lib.rs
@@ -45,7 +45,6 @@ pub mod core_types;
 #[cfg(feature = "nativescript")]
 pub mod nativescript;
 
-#[doc(hidden)]
 pub mod log;
 pub mod object;
 

--- a/gdnative/src/lib.rs
+++ b/gdnative/src/lib.rs
@@ -58,7 +58,7 @@
 // Items, which are #[doc(hidden)] in their original crate and re-exported with a wildcard, lose
 // their hidden status. Re-exporting them manually and hiding the wildcard solves this.
 #[doc(inline)]
-pub use gdnative_core::{core_types, nativescript, object};
+pub use gdnative_core::{core_types, log, nativescript, object};
 
 /// Collection of declarative `godot_*` macros, mostly for GDNative registration and output.
 pub mod macros {


### PR DESCRIPTION
Types and functions in the `log` module should remain visible and part of the public API:

- `Site` is the return type of the trait method `Method::site`, and is necessary to name when implementing the trait manually e.g. for a generic method.
- `print`, `warn` and `error` are safe high-level bindings to the native logging facilities that aren't available elsewhere, and are worthwhile to expose for custom `log` backend implementations that want to use call site information from the logging framework instead.