### PR TITLE
Fixed Logo: off-by-one pixel strip error

### DIFF
--- a/assets/godot-ferris-license.txt
+++ b/assets/godot-ferris-license.txt
@@ -5,6 +5,7 @@ Godot ferris is licensed under a Creative Commons Attribution-NonCommercial-Shar
 ## Ferris Emoji
 
 Ferris emoji, made by Dzuk (noct.zone) are licensed under a Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License. (creativecommons.org/licenses/by-nc-sa/4.0/)
+Minor changes to improve rendering have been applied by godot-rust contributors.
 
 See https://www.rustacean.net/.
 

--- a/assets/godot-ferris.svg
+++ b/assets/godot-ferris.svg
@@ -22,7 +22,7 @@
      id="defs49"><clipPath
        id="_clip2"><path
          id="path13"
-         d="M 2,19 V 10.281 H 30 V 19 l -1.514,4.541 -2.359,0.842 c -6.549,2.339 -13.705,2.339 -20.254,0 L 3.514,23.541 Z" /></clipPath></defs><sodipodi:namedview
+         d="M 1.5,19 V 10.281 H 30.5 V 20 l -1.514,4.541 -2.359,0.842 c -6.549,2.339 -13.705,2.339 -20.254,0 L 3.514,23.541 Z" /></clipPath></defs><sodipodi:namedview
      inkscape:current-layer="svg45"
      inkscape:window-maximized="0"
      inkscape:window-y="18"


### PR DESCRIPTION
The clip path for group "g20" which holds the upper border of the claws was aligned exactly to the inside of the outer border. Due to rounding error, a single-pixel width orange strip was sometimes erroneously drawn where the two borders meet for each claw. Expanding the bounds of the clip path is sufficient to alleviate the issue entirely.

Left: Old
Right: Fixed
https://imgur.com/a/K3dERDL