### PR TITLE
[WIP] Derive property groups

### DIFF
--- a/gdnative-core/src/export/property.rs
+++ b/gdnative-core/src/export/property.rs
@@ -323,6 +323,31 @@ impl PropertyUsage {
     }
 }
 
+/// Marker for defining property groups.
+#[derive(Debug)]
+pub struct GroupMarker;
+
+impl crate::core_types::ToVariant for GroupMarker {
+    #[inline]
+    fn to_variant(&self) -> Variant {
+        Variant::nil()
+    }
+}
+
+impl crate::core_types::FromVariant for GroupMarker {
+    #[inline]
+    fn from_variant(variant: &Variant) -> Result<Self, FromVariantError> {
+        if variant.is_nil() {
+            Ok(Self)
+        } else {
+            Err(FromVariantError::InvalidVariantType {
+                variant_type: variant.get_type(),
+                expected: VariantType::Nil,
+            })
+        }
+    }
+}
+
 /// Placeholder type for exported properties with no backing field.
 ///
 /// This is the go-to type whenever you want to expose a getter/setter to GDScript, which
@@ -585,6 +610,15 @@ mod impl_export {
 
     impl Export for VariantArray<Shared> {
         type Hint = hint::ArrayHint;
+
+        #[inline]
+        fn export_info(hint: Option<Self::Hint>) -> ExportInfo {
+            hint.unwrap_or_default().export_info()
+        }
+    }
+
+    impl Export for GroupMarker {
+        type Hint = hint::GroupHint;
 
         #[inline]
         fn export_info(hint: Option<Self::Hint>) -> ExportInfo {

--- a/gdnative-core/src/export/property/hint.rs
+++ b/gdnative-core/src/export/property/hint.rs
@@ -465,3 +465,29 @@ impl ArrayHint {
         }
     }
 }
+
+/// Provides a hint prefix for group members.
+#[derive(Clone, Debug, Default)]
+pub struct GroupHint {
+    prefix: String,
+}
+
+impl GroupHint {
+    /// Returns a `GroupHint` with a specific prefix.
+    #[inline]
+    pub fn new<S: ToString>(prefix: S) -> Self {
+        Self {
+            prefix: prefix.to_string(),
+        }
+    }
+
+    #[inline]
+    pub fn export_info(self) -> ExportInfo {
+        ExportInfo {
+            variant_type: VariantType::Nil,
+            // hint_kind: sys::godot_property_hint_GODOT_PROPERTY_HINT_TYPE_STRING,
+            hint_kind: sys::godot_property_hint_GODOT_PROPERTY_HINT_NONE,
+            hint_string: GodotString::from_str(&self.prefix),
+        }
+    }
+}


### PR DESCRIPTION
- Adds support for property categories and groups:
  https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_exports.html#adding-script-categories
  https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_exports.html#grouping-properties

This was thrown together to start a discussion. There are no tests, and I am not happy with the implementation. Consider this PR an experiment with no intention to merge. But it could help define the feature and identify shortcomings.

Usage currently looks something like this:

```rust
use gdnative::{
    // GroupMarker is a special unit struct to deal with the way Godot property groups
    // are implemented in property lists.
    export::GroupMarker,
    prelude::*,
};

#[derive(NativeClass)]
#[inherit(Node)]
pub struct MyStruct {
    /// This property is _not_ grouped.
    #[property(default = 8.0, after_set = "Self::update_callback")]
    magnitude: f32,

    /// This property defines a _name_ for your group.
    #[property(group)]
    offset: GroupMarker,

    /// This property directly follows a GroupMarker, so it is a member of the group.
    /// The property name in the editor will be "Offset X".
    #[property(after_set = "Self::update_callback"]
    offset_x: f32,

    /// This property will also be a member of the previously defined group.
    /// The property name in the editor will be "Offset Y".
    #[property(after_set = "Self::update_callback"]
    offset_y: f32,

    /// This property defines a new group and sets a hint prefix for the editor.
    /// The prefix is used by the editor to match property names.
    /// The prefix is removed from the member names.
    #[property(group = "size_")]
    size: GroupMarker,

    /// This property has a prefix matching the previous GroupMarker, so it is a member of the group.
    /// The property name in the editor will be "Width".
    #[property(default = 5, after_set = "Self::update_callback"]
    size_width: u32,

    /// This property has a prefix matching the previous GroupMarker, so it is a member of the group.
    /// The property name in the editor will be "Height".
    #[property(default = 5, after_set = "Self::update_callback"]
    size_height: u32,

    /// This property _does not_ have a prefix matching the previous GroupMarker,
    /// so it is _not_ a member of the group.
    /// The property will appear in the editor below "Magnitude".
    /// This is the behavior of Godot.
    #[property(after_set = "Self::update_callback"]
    duration: f32,
}
```

How it looks in the editor:

![property groups](https://user-images.githubusercontent.com/456942/152676921-af811971-629e-422a-a2ac-9511802bc211.png)

Ideally, I believe that property groups should be declared structurally. The example above has a flat hierarchy that illustrates many issues:

1. The code is generally not easy to read. It is difficult to tell at a glance which properties are grouped together.
2. The editor hint provided by the `group = "..."` arg is easy to typo, which will ruin the grouping of items. Likewise, property names are only conventionally grouped by a prefix.
3. Godot's behavior with property groups leaves a lot to be desired:
    - Defining a group requires a property whose value is `Nil` which provides a name for the group. In the example, `size` and `offset` are both group names, created automatically by the property attribute using the field name as the property's name. The `GroupMarker` type is just a way to feed the `Nil` value to Godot.
    - All properties following another property with the `GROUP` usage flag enabled will become a member of that group. (See the linked GDScript documentation.)
    - The behavior changes when a `hint_string` is provided on the property with the `GROUP` flag: In this case, _only_ properties whose name matches the given hint prefix will become group members. Any other properties will "move" to the top of the list outside of any group. This behavior is surprising, and any number of bugs can cause this to happen by mistake.

With structural declaration, the example could possibly look like this:

```rust
use gdnative::prelude::*;

#[derive(PropertyGroup)]
struct Offset {
    /// Offset along X-axis in meters.
    #[property(after_set = "MyStruct::update_callback"]
    x: f32,

    /// Offset along Y-axis in meters.
    #[property(after_set = "MyStruct::update_callback"]
    y: f32,
}

#[derive(PropertyGroup)]
struct Size {
    /// Width in meters.
    #[property(default = 5, after_set = "MyStruct::update_callback"]
    width: u32,

    /// Height in meters.
    #[property(default = 5, after_set = "MyStruct::update_callback"]
    height: u32,
}

#[derive(NativeClass)]
#[inherit(Node)]
pub struct MyStruct {
    /// This property is _not_ grouped.
    #[property(default = 8.0, after_set = "Self::update_callback")]
    magnitude: f32,

    /// This property defines a _name_ for your group and all of its members.
    #[property(group, no_group_prefix)]
    offset: Offset,

    /// Define another group with its members.
    #[property(group)]
    size: Size,

    /// This property does not belong to a group.
    /// So it will appear in the editor below "Magnitude".
    /// This is the behavior of Godot.
    #[property(after_set = "Self::update_callback"]
    duration: f32,
}
```

This looks more reasonable, but it also has some problems:

1. Godot properties must have a unique name. The derive macro will need to flatten the struct into a single-level property list with e.g. `size.width` being renamed to `size_width` and a hint on the group set to `"size_"` to handle the prefixing. Creating a group without prefix handling would have to be an extra option for the property attribute.
2. The flattening means that getting a property by name may be surprising behavior! Users will have to know that the group creates magically prefixed property names if they ever need to look them up with Godot's property list functions.
3. Hypothetically this could support arbitrary nesting depths, but for simplicity I personally prefer a maximum depth of 2.
4. The way Godot "groups" ungrouped properties at the top of the list is a bit unexpected. But I guess they had to make the UI reasonable. There's nothing we can do about that.
5. Lacking unnamed structs in Rust is unfortunate. We need to declare `Offset` and `Size` as separate types, and they both have to refer back to `MyStruct` for getter/setter functions. At least it makes sense to include hint functions on these separate types.
6. Honestly, I don't know how well this structural property declaration will work. Do we still need `#[property(group)]` for this? Is ``#[derive(PropertyGroup)]` enough? Can we do something better?