### PR TITLE
Make ptrcalls opt-in

### DIFF
--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -273,19 +273,34 @@ jobs:
           - rust: stable
             godot: "3.5.1-stable"
             postfix: ''
+          - rust: stable
+            godot: "3.5.1-stable"
+            postfix: ' (ptrcall)'
+            build_args: '--features ptrcall'
           - rust: nightly
             godot: "3.5.1-stable"
             postfix: ' (nightly)'
+          - rust: nightly
+            godot: "3.5.1-stable"
+            postfix: ' (nightly, ptrcall)'
+            build_args: '--features ptrcall'
           - rust: '1.63'
             godot: "3.5.1-stable"
             postfix: ' (msrv 1.63)'
+          - rust: '1.63'
+            godot: "3.5.1-stable"
+            postfix: ' (msrv 1.63, ptrcall)'
+            build_args: '--features ptrcall'
 
           # Test with oldest supported engine version
           - rust: stable
             godot: "3.2-stable"
             postfix: ''
             build_args: '--features custom-godot'
-
+          - rust: stable
+            godot: "3.2-stable"
+            postfix: ' (ptrcall)'
+            build_args: '--features custom-godot,ptrcall'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/bindings-generator/Cargo.toml
+++ b/bindings-generator/Cargo.toml
@@ -13,6 +13,7 @@ rust-version = "1.63"
 
 [features]
 debug = []
+ptrcall = []
 custom-godot = ["which"]
 
 [dependencies]

--- a/bindings-generator/src/classes.rs
+++ b/bindings-generator/src/classes.rs
@@ -135,6 +135,13 @@ pub(crate) fn generate_enums(class: &GodotClass) -> TokenStream {
                     v.0
                 }
             }
+
+            impl FromVariant for #typ_name {
+                #[inline]
+                fn from_variant(v: &Variant) -> Result<Self, FromVariantError> {
+                    i64::from_variant(v).map(Self::from)
+                }
+            }
         }
     });
 

--- a/gdnative-bindings/Cargo.toml
+++ b/gdnative-bindings/Cargo.toml
@@ -15,6 +15,7 @@ rust-version = "1.63"
 formatted = []
 one-class-one-file = []
 custom-godot = ["gdnative_bindings_generator/custom-godot"]
+ptrcall = ["gdnative_bindings_generator/ptrcall"]
 
 [dependencies]
 gdnative-core = { path = "../gdnative-core", version = "=0.11.0" }

--- a/gdnative-bindings/src/generated.rs
+++ b/gdnative-bindings/src/generated.rs
@@ -1,6 +1,8 @@
 #![allow(unused_variables)]
 
+#[cfg(feature = "ptrcall")]
 use libc;
+
 use libc::c_char;
 use std::mem;
 use std::ptr;

--- a/gdnative-bindings/src/icalls.rs
+++ b/gdnative-bindings/src/icalls.rs
@@ -1,11 +1,14 @@
 #![allow(unused_variables)]
 
+#[cfg(feature = "ptrcall")]
+use gdnative_core::*;
+#[cfg(feature = "ptrcall")]
 use libc;
+
 use std::ptr;
 
 use gdnative_core::core_types::*;
 use gdnative_core::private::get_api;
 use gdnative_core::sys;
-use gdnative_core::*;
 
 include!(concat!(env!("OUT_DIR"), "/icalls.rs"));

--- a/gdnative/Cargo.toml
+++ b/gdnative/Cargo.toml
@@ -19,6 +19,7 @@ default = []
 async = ["gdnative-async"]
 custom-godot = ["gdnative-bindings/custom-godot"]
 formatted = ["gdnative-bindings/formatted", "gdnative-bindings/one-class-one-file"]
+ptrcall = ["gdnative-bindings/ptrcall"]
 serde = ["gdnative-core/serde"]
 
 # Internal

--- a/gdnative/src/lib.rs
+++ b/gdnative/src/lib.rs
@@ -69,6 +69,16 @@
 //!   Enable if the generated binding source code should be human-readable and split
 //!   into multiple files. This can also help IDEs that struggle with a single huge file.
 //!
+//! * **`ptrcall`**<br>
+//!   Enables the `ptrcall` convention for calling Godot API methods. This increases performance, at the
+//!   cost of forward binary compatibility with the engine. Binaries built with `ptrcall` enabled
+//!   **may exhibit undefined behavior** when loaded by a different version of Godot, even when there are
+//!   no breaking API changes as far as GDScript is concerned. Notably, the addition of new default
+//!   parameters breaks any code using `ptrcall`.
+//!
+//!   Cargo features are additive, and as such, it's only necessary to enable this feature for the final
+//!   `cdylib` crates, whenever desired.
+//!
 //! [thread-safety]: https://docs.godotengine.org/en/stable/tutorials/threads/thread_safe_apis.html
 //! [gdnative-overview]: https://godot-rust.github.io/book/gdnative-overview.html
 //! [custom-godot]: https://godot-rust.github.io/book/advanced-guides/custom-godot.html

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -14,6 +14,7 @@ crate-type = ["cdylib"]
 default = []
 type-tag-fallback = ["gdnative/type-tag-fallback"]
 custom-godot = ["gdnative/custom-godot"]
+ptrcall = ["gdnative/ptrcall"]
 
 [dependencies]
 gdnative = { path = "../gdnative", features = ["gd-test", "serde", "async"] }


### PR DESCRIPTION
This implements cuddlefishie's suggestion in #814, but with the semantics reversed to better conform with Cargo's additive combination of features.

- Added the new feature flag `ptrcall`, which enables performant API calls at the cost of forward binary compatibility with the engine.
- Added tests with and without the feature to the full CI suite.

I believe the current semantics to be better, since by making the safer option the default, it helps reduce the surprise factor when someone tries to use the crate with a supposedly compatible version of Godot. Different opinions are welcome.

Note that this only addresses binary compatibility -- #814 is also in a large part an API problem.