### PR TITLE
[gdnative-sys] Pass `cfg!(target_arch)` for macOS

### DIFF
--- a/gdnative-sys/build.rs
+++ b/gdnative-sys/build.rs
@@ -62,6 +62,7 @@ mod header_binding {
         // to double-check them wherever they occur.
 
         assert!(
+            cfg!(target_os = "macos") || // All macOS architectures are supported
             cfg!(target_arch = "x86_64"),
             "unsupported host architecture: build from x86_64 instead"
         );


### PR DESCRIPTION
Add pass condition for macOS.
Thanks to nice rust-toolchain, it just works on both `x86_64` and `Apple silicon`

Issue #981 

Tested on 
- macOS 12.5, Apple M1 and x86_64