### PR TITLE
Handle generics in NativeScript derive and `#[methods]`

### DIFF
--- a/gdnative-derive/src/lib.rs
+++ b/gdnative-derive/src/lib.rs
@@ -493,7 +493,21 @@ pub fn derive_from_variant(input: TokenStream) -> TokenStream {
 ///     #[opt] baz: Option<Ref<Node>>,
 /// }
 /// ```
-#[proc_macro_derive(FromVarargs, attributes(opt))]
+///
+/// ## Field attributes
+///
+/// Attributes can be used to customize behavior of certain fields. All attributes are optional.
+///
+/// ### `#[opt]`
+///
+/// Marks an argument as optional. Required arguments must precede all optional arguments.
+/// Default values are obtained through `Default::default`.
+///
+/// ### `#[skip]`
+///
+/// Instructs the macro to skip a field. Skipped fields do not affect the signature of the
+/// argument list. They may be located anywhere. Values are obtained through `Default::default`.
+#[proc_macro_derive(FromVarargs, attributes(opt, skip))]
 pub fn derive_from_varargs(input: TokenStream) -> TokenStream {
     let derive_input = syn::parse_macro_input!(input as syn::DeriveInput);
     match varargs::derive_from_varargs(derive_input) {

--- a/gdnative-derive/src/lib.rs
+++ b/gdnative-derive/src/lib.rs
@@ -8,7 +8,7 @@ extern crate quote;
 use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::ToTokens;
-use syn::{AttributeArgs, DeriveInput, ItemFn, ItemImpl};
+use syn::{AttributeArgs, DeriveInput, ItemFn, ItemImpl, ItemType};
 
 mod extend_bounds;
 mod methods;
@@ -453,6 +453,41 @@ pub fn derive_native_class(input: TokenStream) -> TokenStream {
     );
 
     TokenStream::from(derived)
+}
+
+/// Wires up necessary internals for a concrete monomorphization of a generic `NativeClass`,
+/// represented as a type alias, so it can be registered.
+///
+/// The monomorphized type will be available to Godot under the name of the type alias,
+/// once registered.
+///
+/// For more context, please refer to [gdnative::derive::NativeClass](NativeClass).
+///
+/// # Examples
+///
+/// ```ignore
+/// #[derive(NativeClass)]
+/// struct Pair<T> {
+///     a: T,
+///     b: T,
+/// }
+///
+/// #[gdnative::derive::monomorphize]
+/// type IntPair = Pair<i32>;
+///
+/// fn init(handle: InitHandle) {
+///     handle.add_class::<IntPair>();
+/// }
+/// ```
+#[proc_macro_attribute]
+pub fn monomorphize(meta: TokenStream, input: TokenStream) -> TokenStream {
+    let args = parse_macro_input!(meta as AttributeArgs);
+    let item_type = parse_macro_input!(input as ItemType);
+
+    match native_script::derive_monomorphize(args, item_type) {
+        Ok(tokens) => tokens.into(),
+        Err(err) => err.to_compile_error().into(),
+    }
 }
 
 #[proc_macro_derive(ToVariant, attributes(variant))]

--- a/gdnative-derive/src/varargs.rs
+++ b/gdnative-derive/src/varargs.rs
@@ -16,7 +16,8 @@ pub(crate) fn derive_from_varargs(input: DeriveInput) -> Result<TokenStream2, sy
 
         let mut generics = with_visitor(
             input.generics,
-            &syn::parse_quote! { ::gdnative::core_types::FromVariant },
+            Some(&syn::parse_quote! { ::gdnative::core_types::FromVariant }),
+            None,
             |visitor| {
                 visitor.visit_data_struct(&struct_data);
             },

--- a/gdnative-derive/src/varargs.rs
+++ b/gdnative-derive/src/varargs.rs
@@ -48,7 +48,13 @@ pub(crate) fn derive_from_varargs(input: DeriveInput) -> Result<TokenStream2, sy
 
         let mut required = Vec::new();
         let mut optional = Vec::new();
+        let mut skipped = Vec::new();
         for field in fields {
+            if field.attrs.iter().any(|attr| attr.path.is_ident("skip")) {
+                skipped.push(field);
+                continue;
+            }
+
             let is_optional = field.attrs.iter().any(|attr| attr.path.is_ident("opt"));
             if !is_optional && !optional.is_empty() {
                 return Err(syn::Error::new(
@@ -111,6 +117,16 @@ pub(crate) fn derive_from_varargs(input: DeriveInput) -> Result<TokenStream2, sy
             .map(|field| format!("{}", field.ty.to_token_stream()))
             .collect::<Vec<_>>();
 
+        let skipped_var_idents = skipped
+            .iter()
+            .enumerate()
+            .map(|(n, field)| {
+                field.ident.clone().unwrap_or_else(|| {
+                    Ident::new(&format!("__skipped_arg_{}", n), Span::call_site())
+                })
+            })
+            .collect::<Vec<_>>();
+
         Ok(quote! {
             #derived
             impl #generics ::gdnative::export::FromVarargs for #ident #generics #where_clause {
@@ -147,9 +163,14 @@ pub(crate) fn derive_from_varargs(input: DeriveInput) -> Result<TokenStream2, sy
                         let #req_var_idents = #req_var_idents.unwrap();
                     )*
 
+                    #(
+                        let #skipped_var_idents = core::default::Default::default();
+                    )*
+
                     std::result::Result::Ok(#ident {
                         #(#req_var_idents,)*
                         #(#opt_var_idents,)*
+                        #(#skipped_var_idents,)*
                     })
                 }
             }

--- a/gdnative-derive/src/variant/bounds.rs
+++ b/gdnative-derive/src/variant/bounds.rs
@@ -14,7 +14,7 @@ pub(crate) fn extend_bounds(
     bound: &syn::Path,
     dir: Direction,
 ) -> Generics {
-    with_visitor(generics, bound, |visitor| {
+    with_visitor(generics, Some(bound), None, |visitor| {
         // iterate through parsed variant representations and visit the types of each field
         fn visit_var_repr<'ast>(
             visitor: &mut BoundsVisitor<'ast>,

--- a/gdnative/tests/ui.rs
+++ b/gdnative/tests/ui.rs
@@ -6,15 +6,16 @@ fn ui_tests() {
     t.pass("tests/ui/derive_pass.rs");
     t.pass("tests/ui/derive_property_basic.rs");
     t.pass("tests/ui/derive_no_inherit.rs");
-    t.compile_fail("tests/ui/derive_fail_property_hint.rs");
     t.compile_fail("tests/ui/derive_fail_inherit_param.rs");
-    t.compile_fail("tests/ui/derive_fail_methods.rs");
-    t.compile_fail("tests/ui/derive_fail_methods_param.rs");
+    t.compile_fail("tests/ui/derive_fail_lifetime.rs");
     t.compile_fail("tests/ui/derive_fail_methods_list.rs");
     t.compile_fail("tests/ui/derive_fail_methods_missing_new.rs");
+    t.compile_fail("tests/ui/derive_fail_methods_param.rs");
     t.compile_fail("tests/ui/derive_fail_methods_special_args.rs");
-    t.compile_fail("tests/ui/derive_fail_userdata.rs");
+    t.compile_fail("tests/ui/derive_fail_methods.rs");
     t.compile_fail("tests/ui/derive_fail_property_empty_hint.rs");
+    t.compile_fail("tests/ui/derive_fail_property_hint.rs");
+    t.compile_fail("tests/ui/derive_fail_userdata.rs");
 
     // Variants
     t.pass("tests/ui/variant_pass.rs");

--- a/gdnative/tests/ui/derive_fail_lifetime.rs
+++ b/gdnative/tests/ui/derive_fail_lifetime.rs
@@ -1,0 +1,16 @@
+use gdnative::prelude::*;
+
+#[derive(NativeClass)]
+struct Foo<'a> {
+    bar: &'a str,
+}
+
+impl<'a> Foo<'a> {
+    fn new(_owner: &Node) -> Self {
+        Foo {
+            bar: "bar",
+        }
+    }
+}
+
+fn main() {}

--- a/gdnative/tests/ui/derive_fail_lifetime.stderr
+++ b/gdnative/tests/ui/derive_fail_lifetime.stderr
@@ -1,0 +1,13 @@
+error[E0478]: lifetime bound not satisfied
+ --> tests/ui/derive_fail_lifetime.rs:3:10
+  |
+3 | #[derive(NativeClass)]
+  |          ^^^^^^^^^^^
+  |
+note: lifetime parameter instantiated with the lifetime `'a` as defined here
+ --> tests/ui/derive_fail_lifetime.rs:4:12
+  |
+4 | struct Foo<'a> {
+  |            ^^
+  = note: but lifetime parameter must outlive the static lifetime
+  = note: this error originates in the derive macro `NativeClass` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/test/project/main.gd
+++ b/test/project/main.gd
@@ -17,6 +17,7 @@ func _ready():
 		status = gdn.call_native("standard_varcall", "run_tests", [])
 
 		status = status && _test_argument_passing_sanity()
+		status = status && _test_generic_class()
 		status = status && _test_optional_args()
 		status = status && yield(_test_async_resume(), "completed")
 
@@ -168,3 +169,30 @@ func _test_async_resume():
 func _get_async_number():
 	yield(get_tree().create_timer(0.1), "timeout")
 	return 39
+
+func _test_generic_class():
+	print(" -- _test_generic_class")
+
+	var int_script = NativeScript.new()
+	int_script.set_library(gdn.library)
+	int_script.set_class_name("IntOps")
+
+	var str_script = NativeScript.new()
+	str_script.set_library(gdn.library)
+	str_script.set_class_name("StrOps")
+	
+	var int_ops = Reference.new()
+	int_ops.set_script(int_script)
+	
+	var str_ops = Reference.new()
+	str_ops.set_script(str_script)
+
+	var status = true
+
+	status = status && int_ops.add(1, 2) == 3
+	status = status && str_ops.add("foo", "bar") == "foobar"
+
+	if !status:
+		printerr("   !! _test_generic_class failed")
+
+	return status

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -9,6 +9,7 @@ mod test_async;
 mod test_constructor;
 mod test_derive;
 mod test_free_ub;
+mod test_generic_class;
 mod test_indexed_props;
 mod test_map_owned;
 mod test_register;
@@ -77,6 +78,7 @@ pub extern "C" fn run_tests(
     status &= test_constructor::run_tests();
     status &= test_derive::run_tests();
     status &= test_free_ub::run_tests();
+    status &= test_generic_class::run_tests();
     status &= test_indexed_props::run_tests();
     status &= test_map_owned::run_tests();
     status &= test_register::run_tests();
@@ -240,6 +242,7 @@ fn init(handle: InitHandle) {
     test_constructor::register(handle);
     test_derive::register(handle);
     test_free_ub::register(handle);
+    test_generic_class::register(handle);
     test_indexed_props::register(handle);
     test_map_owned::register(handle);
     test_register::register(handle);

--- a/test/src/test_generic_class.rs
+++ b/test/src/test_generic_class.rs
@@ -1,0 +1,43 @@
+use std::{marker::PhantomData, ops::Add};
+
+use gdnative::prelude::*;
+
+pub(crate) fn run_tests() -> bool {
+    // Relevant tests in GDScript
+    true
+}
+
+pub(crate) fn register(handle: InitHandle) {
+    handle.add_class::<IntOps>();
+    handle.add_class::<StrOps>();
+}
+
+#[derive(NativeClass)]
+struct GenericOps<T> {
+    _marker: PhantomData<T>,
+}
+
+impl<T> GenericOps<T> {
+    fn new(_base: &Reference) -> Self {
+        GenericOps {
+            _marker: PhantomData,
+        }
+    }
+}
+
+#[methods]
+impl<T> GenericOps<T>
+where
+    T: FromVariant + ToVariant + Add<Output = T> + 'static,
+{
+    #[method]
+    fn add(&self, a: T, b: T) -> T {
+        a + b
+    }
+}
+
+#[gdnative::derive::monomorphize]
+type IntOps = GenericOps<i32>;
+
+#[gdnative::derive::monomorphize]
+type StrOps = GenericOps<GodotString>;


### PR DESCRIPTION
The derive macros are now aware of both lifetime and type parameters. `'static` bounds are added to both kinds, which improves the error message shown when a user tries to put a lifetime into a NativeClass.

This behavior is chosen because unlike type parameters, lifetime parameters aren't very useful in this context: only `'static` would be supported anyway, and any attempted usage is hightly likely to have originated from user error.

Also added the `#[skip]` attribute for skipping fields in `FromVarargs`. This is useful mainly for skipping marker fields in generic code.

Close #601

## Error message

The error message that appears when lifetime parameters are declared for `NativeClass` types now clearly indicate where the problem lies and what the expectations are:

```
error[E0478]: lifetime bound not satisfied
 --> tests/ui/derive_fail_lifetime.rs:3:10
  |
3 | #[derive(NativeClass)]
  |          ^^^^^^^^^^^
  |
note: lifetime parameter instantiated with the lifetime `'a` as defined here
 --> tests/ui/derive_fail_lifetime.rs:4:12
  |
4 | struct Foo<'a> {
  |            ^^
  = note: but lifetime parameter must outlive the static lifetime
  = note: this error originates in the derive macro `NativeClass` (in Nightly builds, run with -Z macro-backtrace for more info)
```

Compares this with the old error message:

```
error[E0726]: implicit elided lifetime not allowed here
 --> tests/ui/derive_fail_lifetime.rs:4:8
  |
4 | struct Foo<'a> {
  |        ^^^ expected lifetime parameter
  |
  = note: assuming a `'static` lifetime...
help: indicate the anonymous lifetime
  |
4 | struct Foo<'_><'a> {
  |           ++++

error[E0106]: missing lifetime specifier
 --> tests/ui/derive_fail_lifetime.rs:4:8
  |
4 | struct Foo<'a> {
  |        ^^^ expected named lifetime parameter
  |
help: consider introducing a named lifetime parameter
  |
3 ~ #[derive(NativeClass<'a>)]
4 ~ struct Foo<'a><'a> {
  |

error[E0277]: the trait bound `&gdnative::prelude::Node: OwnerArg<'_, Reference, Shared
>` is not satisfied
 --> tests/ui/derive_fail_lifetime.rs:3:10
  |
3 | #[derive(NativeClass)]
  |          ^^^^^^^^^^^ the trait `OwnerArg<'_, Reference, Shared>` is not implemented
 for `&gdnative::prelude::Node`
  |
  = help: the following other types implement trait `OwnerArg<'a, T, Own>`:
            &'a T
            TRef<'a, T, Own>
  = note: this error originates in the derive macro `NativeClass` (in Nightly builds, r
un with -Z macro-backtrace for more info)
```

Close #174