### PR TITLE
Expose RPC modes for properties

### DIFF
--- a/examples/rpc/src/client.rs
+++ b/examples/rpc/src/client.rs
@@ -47,6 +47,7 @@ impl ServerPuppet {
     #[method]
     fn on_connected_to_server(&mut self, #[base] owner: TRef<Node>) {
         owner.rpc("greet_server", &[Variant::new("hello")]);
+        owner.rset("foo", 42);
     }
 
     #[method(rpc = "puppet")]

--- a/examples/rpc/src/server.rs
+++ b/examples/rpc/src/server.rs
@@ -8,12 +8,15 @@ const OUT_BANDWIDTH: i64 = 1000;
 
 #[derive(NativeClass)]
 #[inherit(Node)]
-pub struct Server;
+pub struct Server {
+    #[property(rpc = "master", set = "Self::set_foo")]
+    foo: i32,
+}
 
 #[methods]
 impl Server {
     fn new(_owner: &Node) -> Self {
-        Self
+        Self { foo: 0 }
     }
 
     #[method]
@@ -40,5 +43,11 @@ impl Server {
             "return_greeting",
             &[Variant::new("hello")],
         );
+    }
+
+    #[method]
+    fn set_foo(&mut self, #[base] _owner: TRef<Node>, value: i32) {
+        godot_print!("Client sets foo to: {}", value);
+        self.foo = value;
     }
 }

--- a/gdnative-core/src/export/class_builder.rs
+++ b/gdnative-core/src/export/class_builder.rs
@@ -218,17 +218,9 @@ impl<C: NativeClass> ClassBuilder<C> {
     pub(crate) fn add_method(&self, method: ScriptMethod) {
         let method_name = CString::new(method.name).unwrap();
 
-        let rpc = match method.attributes.rpc_mode {
-            RpcMode::Master => sys::godot_method_rpc_mode_GODOT_METHOD_RPC_MODE_MASTER,
-            RpcMode::Remote => sys::godot_method_rpc_mode_GODOT_METHOD_RPC_MODE_REMOTE,
-            RpcMode::Puppet => sys::godot_method_rpc_mode_GODOT_METHOD_RPC_MODE_PUPPET,
-            RpcMode::RemoteSync => sys::godot_method_rpc_mode_GODOT_METHOD_RPC_MODE_REMOTESYNC,
-            RpcMode::Disabled => sys::godot_method_rpc_mode_GODOT_METHOD_RPC_MODE_DISABLED,
-            RpcMode::MasterSync => sys::godot_method_rpc_mode_GODOT_METHOD_RPC_MODE_MASTERSYNC,
-            RpcMode::PuppetSync => sys::godot_method_rpc_mode_GODOT_METHOD_RPC_MODE_PUPPETSYNC,
+        let attr = sys::godot_method_attributes {
+            rpc_type: method.attributes.rpc_mode.sys(),
         };
-
-        let attr = sys::godot_method_attributes { rpc_type: rpc };
 
         let method_desc = sys::godot_instance_method {
             method: method.method_ptr,

--- a/gdnative-core/src/export/method.rs
+++ b/gdnative-core/src/export/method.rs
@@ -96,6 +96,7 @@ type ScriptMethodFn = unsafe extern "C" fn(
     *mut *mut sys::godot_variant,
 ) -> sys::godot_variant;
 
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub enum RpcMode {
     Disabled,
     Remote,
@@ -110,6 +111,20 @@ impl Default for RpcMode {
     #[inline]
     fn default() -> Self {
         RpcMode::Disabled
+    }
+}
+
+impl RpcMode {
+    pub(crate) fn sys(self) -> sys::godot_method_rpc_mode {
+        match self {
+            RpcMode::Master => sys::godot_method_rpc_mode_GODOT_METHOD_RPC_MODE_MASTER,
+            RpcMode::Remote => sys::godot_method_rpc_mode_GODOT_METHOD_RPC_MODE_REMOTE,
+            RpcMode::Puppet => sys::godot_method_rpc_mode_GODOT_METHOD_RPC_MODE_PUPPET,
+            RpcMode::RemoteSync => sys::godot_method_rpc_mode_GODOT_METHOD_RPC_MODE_REMOTESYNC,
+            RpcMode::Disabled => sys::godot_method_rpc_mode_GODOT_METHOD_RPC_MODE_DISABLED,
+            RpcMode::MasterSync => sys::godot_method_rpc_mode_GODOT_METHOD_RPC_MODE_MASTERSYNC,
+            RpcMode::PuppetSync => sys::godot_method_rpc_mode_GODOT_METHOD_RPC_MODE_PUPPETSYNC,
+        }
     }
 }
 

--- a/gdnative-core/src/export/property.rs
+++ b/gdnative-core/src/export/property.rs
@@ -15,6 +15,8 @@ use crate::object::ownership::Shared;
 use crate::object::{GodotObject, Instance, Ref};
 use crate::private::get_api;
 
+use super::RpcMode;
+
 mod accessor;
 mod invalid_accessor;
 
@@ -78,6 +80,7 @@ pub struct PropertyBuilder<'a, C, T: Export, S = InvalidSetter<'a>, G = InvalidG
     default: Option<T>,
     hint: Option<T::Hint>,
     usage: PropertyUsage,
+    rpc_mode: RpcMode,
     class_builder: &'a ClassBuilder<C>,
 }
 
@@ -96,6 +99,7 @@ where
             default: None,
             hint: None,
             usage: PropertyUsage::DEFAULT,
+            rpc_mode: RpcMode::Disabled,
             class_builder,
         }
     }
@@ -119,7 +123,7 @@ where
         let default = self.default.to_variant();
 
         let mut attr = sys::godot_property_attributes {
-            rset_type: sys::godot_method_rpc_mode_GODOT_METHOD_RPC_MODE_DISABLED, // TODO(#995)
+            rset_type: self.rpc_mode.sys(),
             type_: variant_type as sys::godot_int,
             hint: hint_kind,
             hint_string: hint_string.to_sys(),
@@ -161,6 +165,7 @@ where
             default: self.default,
             hint: self.hint,
             usage: self.usage,
+            rpc_mode: self.rpc_mode,
             class_builder: self.class_builder,
         }
     }
@@ -184,6 +189,7 @@ where
             default: self.default,
             hint: self.hint,
             usage: self.usage,
+            rpc_mode: self.rpc_mode,
             class_builder: self.class_builder,
         }
     }
@@ -205,6 +211,7 @@ where
             default: self.default,
             hint: self.hint,
             usage: self.usage,
+            rpc_mode: self.rpc_mode,
             class_builder: self.class_builder,
         }
     }
@@ -226,6 +233,7 @@ where
             default: self.default,
             hint: self.hint,
             usage: self.usage,
+            rpc_mode: self.rpc_mode,
             class_builder: self.class_builder,
         }
     }
@@ -247,6 +255,7 @@ where
             default: self.default,
             hint: self.hint,
             usage: self.usage,
+            rpc_mode: self.rpc_mode,
             class_builder: self.class_builder,
         }
     }
@@ -268,6 +277,7 @@ where
             default: self.default,
             hint: self.hint,
             usage: self.usage,
+            rpc_mode: self.rpc_mode,
             class_builder: self.class_builder,
         }
     }
@@ -291,6 +301,13 @@ where
     #[inline]
     pub fn with_usage(mut self, usage: PropertyUsage) -> Self {
         self.usage = usage;
+        self
+    }
+
+    /// Sets a RPC mode.
+    #[inline]
+    pub fn with_rpc_mode(mut self, rpc_mode: RpcMode) -> Self {
+        self.rpc_mode = rpc_mode;
         self
     }
 }

--- a/gdnative-derive/src/lib.rs
+++ b/gdnative-derive/src/lib.rs
@@ -13,6 +13,7 @@ use syn::{parse::Parser, AttributeArgs, DeriveInput, ItemFn, ItemImpl, ItemType}
 mod methods;
 mod native_script;
 mod profiled;
+mod syntax;
 mod utils;
 mod varargs;
 mod variant;
@@ -267,6 +268,11 @@ pub fn profiled(meta: TokenStream, input: TokenStream) -> TokenStream {
 /// - `no_editor`
 ///
 ///   Hides the property from the editor. Does not prevent it from being sent over network or saved in storage.
+///
+/// - `rpc = "selected_rpc"`
+///
+///   Sets the [Multiplayer API RPC Mode](https://docs.godotengine.org/en/stable/classes/class_multiplayerapi.html?highlight=RPC#enumerations) for the property.
+///   See the `#[method]` documentation below for possible values and their semantics.
 ///
 /// ### `#[methods]`
 /// Adds the necessary information to a an `impl` block to register the properties and methods with Godot.

--- a/gdnative-derive/src/methods.rs
+++ b/gdnative-derive/src/methods.rs
@@ -7,57 +7,12 @@ use proc_macro2::TokenStream as TokenStream2;
 use quote::{quote, ToTokens};
 use std::boxed::Box;
 
+use crate::syntax::rpc_mode::RpcMode;
 use crate::utils::find_non_concrete;
 
 use self::mixin_args::{MixinArgsBuilder, MixinKind};
 
 mod mixin_args;
-
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
-pub enum RpcMode {
-    Disabled,
-    Remote,
-    RemoteSync,
-    Master,
-    Puppet,
-    MasterSync,
-    PuppetSync,
-}
-
-impl RpcMode {
-    fn parse(s: &str) -> Option<Self> {
-        match s {
-            "remote" => Some(RpcMode::Remote),
-            "remote_sync" => Some(RpcMode::RemoteSync),
-            "master" => Some(RpcMode::Master),
-            "puppet" => Some(RpcMode::Puppet),
-            "disabled" => Some(RpcMode::Disabled),
-            "master_sync" => Some(RpcMode::MasterSync),
-            "puppet_sync" => Some(RpcMode::PuppetSync),
-            _ => None,
-        }
-    }
-}
-
-impl Default for RpcMode {
-    fn default() -> Self {
-        RpcMode::Disabled
-    }
-}
-
-impl ToTokens for RpcMode {
-    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
-        match self {
-            RpcMode::Disabled => tokens.extend(quote!(RpcMode::Disabled)),
-            RpcMode::Remote => tokens.extend(quote!(RpcMode::Remote)),
-            RpcMode::RemoteSync => tokens.extend(quote!(RpcMode::RemoteSync)),
-            RpcMode::Master => tokens.extend(quote!(RpcMode::Master)),
-            RpcMode::Puppet => tokens.extend(quote!(RpcMode::Puppet)),
-            RpcMode::MasterSync => tokens.extend(quote!(RpcMode::MasterSync)),
-            RpcMode::PuppetSync => tokens.extend(quote!(RpcMode::PuppetSync)),
-        }
-    }
-}
 
 pub(crate) struct ClassMethodExport {
     pub(crate) class_ty: Box<Type>,

--- a/gdnative-derive/src/native_script/mod.rs
+++ b/gdnative-derive/src/native_script/mod.rs
@@ -100,6 +100,8 @@ pub(crate) fn derive_native_class(derive_input: &DeriveInput) -> Result<TokenStr
                     .map(|default_value| quote!(.with_default(#default_value)));
                 let with_hint = config.hint.map(|hint_fn| quote!(.with_hint(#hint_fn())));
                 let with_usage = config.no_editor.then(|| quote!(.with_usage(#gdnative_core::export::PropertyUsage::NOEDITOR)));
+                let with_rpc_mode = config.rpc_mode.map(|rpc_mode| quote!(.with_rpc_mode(#gdnative_core::export::#rpc_mode)));
+
                 // check whether this property type is `Property<T>`. if so, extract T from it.
                 let property_ty = match config.ty {
                     Type::Path(ref path) => path
@@ -176,6 +178,7 @@ pub(crate) fn derive_native_class(derive_input: &DeriveInput) -> Result<TokenStr
                         #with_default
                         #with_hint
                         #with_usage
+                        #with_rpc_mode
                         #with_getter
                         #with_setter
                         .done();

--- a/gdnative-derive/src/syntax.rs
+++ b/gdnative-derive/src/syntax.rs
@@ -1,0 +1,1 @@
+pub mod rpc_mode;

--- a/gdnative-derive/src/syntax/rpc_mode.rs
+++ b/gdnative-derive/src/syntax/rpc_mode.rs
@@ -1,0 +1,47 @@
+use quote::{quote, ToTokens};
+
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+pub enum RpcMode {
+    Disabled,
+    Remote,
+    RemoteSync,
+    Master,
+    Puppet,
+    MasterSync,
+    PuppetSync,
+}
+
+impl RpcMode {
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            "remote" => Some(RpcMode::Remote),
+            "remote_sync" => Some(RpcMode::RemoteSync),
+            "master" => Some(RpcMode::Master),
+            "puppet" => Some(RpcMode::Puppet),
+            "disabled" => Some(RpcMode::Disabled),
+            "master_sync" => Some(RpcMode::MasterSync),
+            "puppet_sync" => Some(RpcMode::PuppetSync),
+            _ => None,
+        }
+    }
+}
+
+impl Default for RpcMode {
+    fn default() -> Self {
+        RpcMode::Disabled
+    }
+}
+
+impl ToTokens for RpcMode {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        match self {
+            RpcMode::Disabled => tokens.extend(quote!(RpcMode::Disabled)),
+            RpcMode::Remote => tokens.extend(quote!(RpcMode::Remote)),
+            RpcMode::RemoteSync => tokens.extend(quote!(RpcMode::RemoteSync)),
+            RpcMode::Master => tokens.extend(quote!(RpcMode::Master)),
+            RpcMode::Puppet => tokens.extend(quote!(RpcMode::Puppet)),
+            RpcMode::MasterSync => tokens.extend(quote!(RpcMode::MasterSync)),
+            RpcMode::PuppetSync => tokens.extend(quote!(RpcMode::PuppetSync)),
+        }
+    }
+}


### PR DESCRIPTION
This adds:

- The `PropertyBuilder::with_rpc_mode` method
- The `#[property(rpc = "mode")]` syntax for the NativeClass macro

Close #995