### PR TITLE
Impl invalid accessors for inconvertible types

### DIFF
--- a/.github/composite/godot/action.yml
+++ b/.github/composite/godot/action.yml
@@ -62,12 +62,12 @@ runs:
         cd test;
         mkdir -p ./project/lib;
         cp ../target/debug/libgdnative_test.so ./project/lib/;
-        ${GODOT_BIN} --path ./project/ > >(tee "${{ runner.temp }}/stdout.log") 2> >(tee "${{ runner.temp }}/stderr.log");
+        ${GODOT_BIN} --verbose --path ./project/ > >(tee "${{ runner.temp }}/stdout.log") 2> >(tee "${{ runner.temp }}/stderr.log");
         bash ../tools/check-test-output.sh "${{ runner.temp }}/stdout.log" "${{ runner.temp }}/stderr.log";
         if [[ $? -ne 0 ]]; then
           exit 1;
         fi;
-        ${GODOT_BIN} -e --path ./project/ --run-editor-tests > >(tee "${{ runner.temp }}/stdout.log") 2> >(tee "${{ runner.temp }}/stderr.log");
+        ${GODOT_BIN} --verbose -e --path ./project/ --run-editor-tests > >(tee "${{ runner.temp }}/stdout.log") 2> >(tee "${{ runner.temp }}/stderr.log");
         bash ../tools/check-test-output.sh "${{ runner.temp }}/stdout.log" "${{ runner.temp }}/stderr.log";
         if [[ $? -ne 0 ]]; then
           exit 1;
@@ -75,12 +75,12 @@ runs:
         cargo build --features type-tag-fallback ${{ inputs.rust_extra_args }}
         mkdir -p ./project/lib;
         cp ../target/debug/libgdnative_test.so ./project/lib/;
-        ${GODOT_BIN} --path ./project/ > >(tee "${{ runner.temp }}/stdout.log") 2> >(tee "${{ runner.temp }}/stderr.log");
+        ${GODOT_BIN} --verbose --path ./project/ > >(tee "${{ runner.temp }}/stdout.log") 2> >(tee "${{ runner.temp }}/stderr.log");
         bash ../tools/check-test-output.sh "${{ runner.temp }}/stdout.log" "${{ runner.temp }}/stderr.log";
         if [[ $? -ne 0 ]]; then
           exit 1;
         fi;
-        ${GODOT_BIN} -e --path ./project/ --run-editor-tests > >(tee "${{ runner.temp }}/stdout.log") 2> >(tee "${{ runner.temp }}/stderr.log");
+        ${GODOT_BIN} --verbose -e --path ./project/ --run-editor-tests > >(tee "${{ runner.temp }}/stdout.log") 2> >(tee "${{ runner.temp }}/stderr.log");
         bash ../tools/check-test-output.sh "${{ runner.temp }}/stdout.log" "${{ runner.temp }}/stderr.log";
         if [[ $? -ne 0 ]]; then
           exit 1;

--- a/gdnative-core/src/export/property/invalid_accessor.rs
+++ b/gdnative-core/src/export/property/invalid_accessor.rs
@@ -2,7 +2,7 @@
 
 use std::mem;
 
-use crate::core_types::{FromVariant, ToVariant, Variant};
+use crate::core_types::Variant;
 use crate::export::{class_registry, NativeClass};
 
 use super::accessor::{RawGetter, RawSetter};
@@ -78,7 +78,7 @@ extern "C" fn invalid_free_func(data: *mut libc::c_void) {
     mem::drop(data)
 }
 
-unsafe impl<'l, C: NativeClass, T: FromVariant> RawSetter<C, T> for InvalidSetter<'l> {
+unsafe impl<'l, C: NativeClass, T> RawSetter<C, T> for InvalidSetter<'l> {
     #[inline]
     unsafe fn into_godot_function(self) -> sys::godot_property_set_func {
         let mut set = sys::godot_property_set_func::default();
@@ -95,7 +95,7 @@ unsafe impl<'l, C: NativeClass, T: FromVariant> RawSetter<C, T> for InvalidSette
     }
 }
 
-unsafe impl<'l, C: NativeClass, T: ToVariant> RawGetter<C, T> for InvalidGetter<'l> {
+unsafe impl<'l, C: NativeClass, T> RawGetter<C, T> for InvalidGetter<'l> {
     #[inline]
     unsafe fn into_godot_function(self) -> sys::godot_property_get_func {
         let mut get = sys::godot_property_get_func::default();

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -104,6 +104,7 @@ godot_itest! {
         // Should not panic due to conversion failure
         let option = node.get_node("does not exist");
         assert!(option.is_none());
+        node.free();
     }
 }
 


### PR DESCRIPTION
The invalid accessors used to require conversion traits for the property types. This prevented users from registering read-only properties of types that only implement `ToVariant`.