### PR TITLE
Remove Export impls with surprising behavior

### DIFF
--- a/examples/property-export/GDScriptPrinter.gd
+++ b/examples/property-export/GDScriptPrinter.gd
@@ -4,17 +4,17 @@ func _ready():
 	var rust = get_node("../PropertyExport")
 
 	print("\n-----------------------------------------------------------------")
-	print("Print from GDScript (note the lexicographically ordered map/set):")
-	print("  Vec (name):");
+	print("Print from GDScript:")
+	print("  PoolArray<GodotString>:");
 	for name in rust.name_vec:
 		print("  * %s" % name)
 
-	print("\n  HashMap (string -> color):")
+	print("\n  Dictionary (string -> color):")
 	for string in rust.color_map:
 		var color = rust.color_map[string]
 		print("  * %s -> #%s" % [string, color.to_html(false)]);
 
-	print("\n  HashSet (ID):")
+	print("\n  PoolArray<i32>:")
 	for id in rust.id_set:
 		print("  * %s" % id)
 

--- a/examples/property-export/Main.tscn
+++ b/examples/property-export/Main.tscn
@@ -12,13 +12,13 @@ library = ExtResource( 1 )
 
 [node name="PropertyExport" type="Node" parent="."]
 script = SubResource( 1 )
-name_vec = [ "Godot", "Godette", "Go ." ]
+name_vec = PoolStringArray("Godot", "Godette", "Go .")
 color_map = {
 "blue": Color( 0.184314, 0.160784, 0.8, 1 ),
 "green": Color( 0.0941176, 0.447059, 0.192157, 1 ),
 "teal": Color( 0.0941176, 0.423529, 0.564706, 1 )
 }
-id_set = [ 21, 77, 8, 90 ]
+id_set = PoolIntArray(21, 77, 8, 90)
 
 [node name="GDScriptPrinter" type="Node" parent="."]
 script = ExtResource( 2 )

--- a/examples/property-export/src/lib.rs
+++ b/examples/property-export/src/lib.rs
@@ -1,18 +1,16 @@
 use gdnative::prelude::*;
 
-use std::collections::{HashMap, HashSet};
-
 #[derive(NativeClass, Default)]
 #[inherit(Node)]
 pub struct PropertyExport {
     #[property]
-    name_vec: Vec<String>,
+    name_vec: PoolArray<GodotString>,
 
     #[property]
-    color_map: HashMap<GodotString, Color>,
+    color_map: Dictionary,
 
     #[property]
-    id_set: HashSet<i64>,
+    id_set: PoolArray<i32>,
 }
 
 #[methods]
@@ -24,19 +22,20 @@ impl PropertyExport {
     #[method]
     fn _ready(&self) {
         godot_print!("------------------------------------------------------------------");
-        godot_print!("Print from Rust (note the unordered map/set):");
-        godot_print!("  Vec (name):");
-        for name in &self.name_vec {
+        godot_print!("Print from Rust:");
+        godot_print!("  PoolArray<GodotString>:");
+        for name in &*self.name_vec.read() {
             godot_print!("  * {}", name);
         }
 
-        godot_print!("\n  HashMap (string -> color):");
+        godot_print!("\n  Dictionary (string -> color):");
         for (string, color) in &self.color_map {
+            let color = Color::from_variant(&color).unwrap();
             godot_print!("  * {} -> #{}", string, color.to_html(false));
         }
 
-        godot_print!("\n  HashSet (ID):");
-        for id in &self.id_set {
+        godot_print!("\n  PoolArray<i32>:");
+        for id in &*self.id_set.read() {
             godot_print!("  * {}", id);
         }
     }


### PR DESCRIPTION
Also added documentation on the rationales behind leaving `Export` unimplemented for standard Rust collections, pointing to alternatives.

Close #1009