### PR TITLE
Move version detection out of user crate

### DIFF
--- a/gdnative-core/Cargo.toml
+++ b/gdnative-core/Cargo.toml
@@ -15,6 +15,7 @@ rust-version = "1.63"
 default = []
 gd-test = []
 type-tag-fallback = []
+custom-godot = []
 
 [dependencies]
 gdnative-sys = { path = "../gdnative-sys", version = "=0.11.3" }
@@ -26,11 +27,12 @@ atomic-take = "1"
 bitflags = "1"
 glam = "0.22"
 indexmap = "1"
+inventory = { version = "0.3", optional = true }
 libc = "0.2"
 once_cell = "1"
 parking_lot = "0.12"
+semver = "1"
 serde = { version = "1", features = ["derive"], optional = true }
-inventory = { version = "0.3", optional = true }
 
 [dev-dependencies]
 gdnative = { path = "../gdnative" } # for doc-tests

--- a/gdnative-core/src/init/diagnostics.rs
+++ b/gdnative-core/src/init/diagnostics.rs
@@ -5,8 +5,12 @@
 //! any problems were found. This is so that they can be freely improved without compatibility
 //! concerns.
 
+mod godot_version_mismatch;
 mod missing_manual_registration;
 mod missing_suggested_diagnostics;
+
+#[doc(inline)]
+pub use godot_version_mismatch::godot_version_mismatch;
 
 #[doc(inline)]
 pub use missing_manual_registration::missing_manual_registration;

--- a/gdnative-core/src/init/diagnostics/godot_version_mismatch.rs
+++ b/gdnative-core/src/init/diagnostics/godot_version_mismatch.rs
@@ -1,0 +1,127 @@
+use semver::{BuildMetadata, Prerelease};
+
+use crate::core_types::Dictionary;
+use crate::core_types::FromVariant;
+use crate::object::ownership::Unique;
+use crate::private::{get_api, EngineMethodTable};
+
+/// Checks the version number of the host Godot instance to see if it matches the generated API.
+/// Returns `true` if the test isn't applicable, or if no mismatch was found.
+#[inline]
+pub fn godot_version_mismatch() -> bool {
+    let ret = check_godot_version_mismatch();
+    if !ret {
+        godot_warn!(concat!(
+            "gdnative-core: GDNative version mismatches may lead to subtle bugs, undefined behavior or crashes at runtime.\n",
+            "Apply the 'custom-godot' feature if you want to use current godot-rust with another Godot engine version.",
+        ));
+    }
+
+    ret
+}
+
+#[cfg(feature = "custom-godot")]
+fn check_godot_version_mismatch() -> bool {
+    true
+}
+
+#[cfg(not(feature = "custom-godot"))]
+fn check_godot_version_mismatch() -> bool {
+    use semver::VersionReq;
+
+    let version = if let Some(version) = godot_version() {
+        version
+    } else {
+        godot_warn!("gdnative-core: failed to get version info from the engine.");
+        return false;
+    };
+
+    let version_req = VersionReq::parse("~3.5.1").unwrap();
+
+    if version_req.matches(&version) {
+        true
+    } else {
+        godot_warn!("This godot-rust version is only compatible with Godot `{version_req}`; detected version `{version}`.");
+        false
+    }
+}
+
+fn godot_version() -> Option<semver::Version> {
+    let version = unsafe {
+        let api = get_api();
+        let engine = (api.godot_global_get_singleton)(b"Engine\0".as_ptr() as *mut _);
+
+        let mut dictionary = sys::godot_dictionary::default();
+
+        (api.godot_method_bind_ptrcall)(
+            EngineMethodTable::get(api).get_version_info,
+            engine,
+            [].as_mut_ptr() as *mut _,
+            &mut dictionary as *mut _ as *mut _,
+        );
+
+        Dictionary::<Unique>::from_sys(dictionary)
+    };
+
+    let major = u64::from_variant(&version.get("major")?).ok()?;
+    let minor = u64::from_variant(&version.get("minor")?).ok()?;
+    let patch = u64::from_variant(&version.get("patch")?).ok()?;
+
+    let pre = version
+        .get("status")
+        .and_then(|v| {
+            let s = String::from_variant(&v).ok()?;
+            if s == "stable" {
+                return None;
+            }
+
+            let s = s.chars().map(sanitize_for_semver).collect::<String>();
+            Some(Prerelease::new(&s).expect("string sanitized"))
+        })
+        .unwrap_or(Prerelease::EMPTY);
+
+    let build = {
+        let mut build_metadata = String::new();
+        let mut sep = false;
+
+        if let Some(build_name) = version
+            .get("build")
+            .and_then(|v| String::from_variant(&v).ok())
+        {
+            build_metadata.extend(build_name.chars().map(sanitize_for_semver));
+            sep = true;
+        };
+
+        if let Some(hash) = version
+            .get("hash")
+            .and_then(|v| String::from_variant(&v).ok())
+        {
+            if sep {
+                build_metadata.push('.');
+            }
+            build_metadata.extend(hash.chars().map(sanitize_for_semver));
+        };
+
+        if build_metadata.is_empty() {
+            BuildMetadata::EMPTY
+        } else {
+            BuildMetadata::new(&build_metadata).expect("build metadata sanitized")
+        }
+    };
+
+    Some(semver::Version {
+        major,
+        minor,
+        patch,
+        pre,
+        build,
+    })
+}
+
+fn sanitize_for_semver(s: char) -> char {
+    if s.is_ascii_alphanumeric() {
+        s
+    } else {
+        '-'
+    }
+}

--- a/gdnative-core/src/init/macros.rs
+++ b/gdnative-core/src/init/macros.rs
@@ -35,30 +35,15 @@ macro_rules! godot_nativescript_init {
                 return;
             }
 
-            // Compatibility warning if using in-house Godot version (not applicable for custom ones)
-            #[cfg(not(feature = "custom-godot"))]
-            {
-                use $crate::core_types::Variant;
-
-                let engine = gdnative::api::Engine::godot_singleton();
-                let info = engine.get_version_info();
-
-                if info.get("major").expect("major version") != Variant::new(3)
-                || info.get("minor").expect("minor version") != Variant::new(5)
-                || info.get("patch").expect("patch version") < Variant::new(1) {
-                    let string = info.get("string").expect("version str").to::<String>().expect("version str type");
-                    $crate::log::godot_warn!(
-                        "This godot-rust version is only compatible with Godot >= 3.5.1 and < 3.6; detected version {}.\n\
-                        GDNative mismatches may lead to subtle bugs, undefined behavior or crashes at runtime.\n\
-                	    Apply the 'custom-godot' feature if you want to use current godot-rust with another Godot engine version.",
-                        string
-                    );
-                }
-            }
-
             $crate::private::report_panics("nativescript_init", || {
-                $crate::init::auto_register($crate::init::InitHandle::new(handle, $crate::init::InitLevel::AUTO));
-                $callback($crate::init::InitHandle::new(handle, $crate::init::InitLevel::USER));
+                $crate::init::auto_register($crate::init::InitHandle::new(
+                    handle,
+                    $crate::init::InitLevel::AUTO,
+                ));
+                $callback($crate::init::InitHandle::new(
+                    handle,
+                    $crate::init::InitLevel::USER,
+                ));
 
                 $crate::init::diagnostics::missing_suggested_diagnostics();
             });
@@ -102,6 +87,8 @@ macro_rules! godot_gdnative_init {
                 // Init errors should be reported by bind_api.
                 return;
             }
+
+            $crate::init::diagnostics::godot_version_mismatch();
 
             $crate::private::report_panics("gdnative_init", || {
                 let init_info = $crate::init::InitializeInfo::new(options);

--- a/gdnative-core/src/private.rs
+++ b/gdnative-core/src/private.rs
@@ -35,6 +35,7 @@ pub unsafe fn bind_api(options: *mut sys::godot_gdnative_init_options) -> bool {
     ObjectMethodTable::get(get_api());
     ReferenceMethodTable::get(get_api());
     NativeScriptMethodTable::get(get_api());
+    EngineMethodTable::get(get_api());
 
     true
 }
@@ -325,4 +326,9 @@ make_method_table!(struct NativeScriptMethodTable for NativeScript {
     set_class_name,
     set_library,
     new,
+});
+
+// `Engine` is known to the engine as `_Engine`.
+make_method_table!(struct EngineMethodTable for _Engine {
+    get_version_info,
 });

--- a/gdnative/Cargo.toml
+++ b/gdnative/Cargo.toml
@@ -17,7 +17,7 @@ rust-version = "1.63"
 # Public
 default = []
 async = ["gdnative-async"]
-custom-godot = ["gdnative-bindings/custom-godot"]
+custom-godot = ["gdnative-bindings/custom-godot", "gdnative-core/custom-godot"]
 formatted = ["gdnative-bindings/formatted", "gdnative-bindings/one-class-one-file"]
 ptrcall = ["gdnative-bindings/ptrcall"]
 serde = ["gdnative-core/serde"]


### PR DESCRIPTION
This should make the `custom-godot` feature silence the warning properly. Currently, the version requirement is hard-coded, but it should be easy to later introduce a mechanism where the versions requirements can be collected from `-sys` and `-bindings` and combined, for better usefulness and less maintenance work in the future.

Close #1023