### PR TITLE
Fix TODO detection in CI

### DIFF
--- a/tools/detect-todo.sh
+++ b/tools/detect-todo.sh
@@ -67,7 +67,7 @@ fi
 
 # Actual run
 
-rg -iTh -Tsh --pcre2 "$REGEX"
+rg -iTh -Tsh --pcre2 "$REGEX" "$(pwd)"
 if [[ $? -eq 0 ]]
 then
     echo 'Found TODO comments without issue numbers.'


### PR DESCRIPTION
For some reason, ripgrep cannot infer the directory to search in on CI like it can when ran locally. Passing the working directory explicitly fixes this.