### PR TITLE
Remove Deprecated Usage of f32 and u32

### DIFF
--- a/examples/dodge-the-creeps/src/main_scene.rs
+++ b/examples/dodge-the-creeps/src/main_scene.rs
@@ -95,7 +95,7 @@ impl Main {
         let mob_scene: Ref<RigidBody2D, _> = instance_scene(&self.mob);
 
         let mut rng = rand::thread_rng();
-        let offset = rng.gen_range(std::u32::MIN..std::u32::MAX);
+        let offset = rng.gen_range(u32::MIN..u32::MAX);
 
         mob_spawn_location.set_offset(offset.into());
 

--- a/gdnative-core/src/core_types/geom/basis.rs
+++ b/gdnative-core/src/core_types/geom/basis.rs
@@ -697,9 +697,9 @@ mod tests {
 
         let vector = Vector3::new(4.0, 5.0, 6.0);
 
-        assert!((basis.tdotx(vector) - 32.0).abs() < std::f32::EPSILON);
-        assert!((basis.tdoty(vector) - 47.0).abs() < std::f32::EPSILON);
-        assert!((basis.tdotz(vector) - 62.0).abs() < std::f32::EPSILON);
+        assert!((basis.tdotx(vector) - 32.0).abs() < f32::EPSILON);
+        assert!((basis.tdoty(vector) - 47.0).abs() < f32::EPSILON);
+        assert!((basis.tdotz(vector) - 62.0).abs() < f32::EPSILON);
     }
 
     #[test]


### PR DESCRIPTION
std::f32::EPSILON (core::f32::EPSILON) → f32::EPSILON
std::u32::MIN (core::u32::MIN) → u32::MIN
std::u32::MAX (core::u32::MAX) → u32::MAX