### PR TITLE
Proof of concept: Register wrapped functions

### DIFF
--- a/gdnative-core/src/init/private.rs
+++ b/gdnative-core/src/init/private.rs
@@ -12,6 +12,7 @@ pub unsafe fn gdnative_init<C: GDNativeCallbacks>(
         return;
     }
 
+    crate::private::init_main_thread_id();
     crate::init::diagnostics::godot_version_mismatch();
 
     crate::private::report_panics("gdnative_init", || {

--- a/gdnative-core/src/lib.rs
+++ b/gdnative-core/src/lib.rs
@@ -58,6 +58,7 @@ pub mod init;
 pub mod log;
 pub mod object;
 pub mod profiler;
+pub mod register;
 
 /// Internal low-level API for use by macros and generated bindings. Not a part of the public API.
 #[doc(hidden)]

--- a/gdnative-core/src/register/class.rs
+++ b/gdnative-core/src/register/class.rs
@@ -1,0 +1,62 @@
+use std::{ffi::c_void, panic::RefUnwindSafe};
+
+use super::convert::{alloc_data, unalloc_data, FromBasePtr, FunctionWithSite};
+
+// TODO: struct ClassHandle
+// TODO: struct Class register
+
+unsafe extern "C" fn call_create<F, Class, Base>(
+    base: *mut sys::godot_object,
+    method_data: *mut c_void,
+) -> *mut c_void
+where
+    F: Fn(Base) -> Class + 'static + RefUnwindSafe,
+    Class: 'static,
+    Base: for<'a> FromBasePtr<'a>,
+{
+    let FunctionWithSite { site, function } = FunctionWithSite::<F>::as_self(&method_data);
+
+    std::panic::catch_unwind(move || {
+        crate::private::assert_main_thread();
+
+        let base = Base::from_base_ptr(&base);
+
+        // TODO: emplace create
+        let user_data = function(base);
+        alloc_data(user_data)
+    })
+    .unwrap_or_else(|e| {
+        crate::log::error(*site, "Class create panicked");
+        crate::private::print_panic_error(e);
+        std::ptr::null_mut()
+    })
+}
+
+unsafe extern "C" fn call_destroy<F, Class, Base>(
+    base: *mut sys::godot_object,
+    method_data: *mut c_void,
+    user_data: *mut c_void,
+) where
+    F: Fn(Class, Base) + 'static + RefUnwindSafe,
+    Class: 'static,
+    Base: for<'a> FromBasePtr<'a>,
+{
+    let FunctionWithSite { site, function } = FunctionWithSite::<F>::as_self(&method_data);
+
+    std::panic::catch_unwind(move || {
+        if user_data.is_null() {
+            return; // Nothing to destroy has been created
+        }
+
+        crate::private::assert_main_thread();
+
+        let user_data = unalloc_data::<Class>(user_data);
+        let base = Base::from_base_ptr(&base);
+
+        function(user_data, base);
+    })
+    .unwrap_or_else(|e| {
+        crate::log::error(*site, "Class create panicked");
+        crate::private::print_panic_error(e);
+    });
+}

--- a/gdnative-core/src/register/convert.rs
+++ b/gdnative-core/src/register/convert.rs
@@ -1,0 +1,137 @@
+use std::{
+    ffi::{c_int, c_void},
+    mem::transmute,
+    ptr::NonNull,
+};
+
+use crate::{
+    core_types::Variant,
+    object::{ownership::Shared, GodotObject, Ref, TRef},
+};
+
+#[inline]
+pub(crate) fn alloc_data<T: 'static>(data: T) -> *mut c_void {
+    Box::into_raw(Box::new(data)).cast::<c_void>()
+}
+
+#[inline]
+pub(crate) unsafe fn unalloc_data<T: 'static>(data: *mut c_void) -> T {
+    // Move a value from a Box back to the stack by dereferencing
+    // https://doc.rust-lang.org/std/boxed/index.html
+    // https://github.com/rust-lang/rust/issues/80437
+    *Box::from_raw(data.cast::<T>())
+}
+
+pub(crate) unsafe extern "C" fn free_data<T: 'static>(data: *mut c_void) {
+    drop(unalloc_data::<T>(data))
+}
+
+#[inline]
+pub(crate) unsafe fn as_class<'a, Class, T>(user_data: &'a *mut c_void) -> &'a T
+where
+    &'static Class: AsRef<T> + 'static,
+{
+    let Some(user_data) = user_data.cast::<Class>().as_ref() else {
+        panic!(
+            "user data pointer for {} is null (did the constructor fail?)",
+            std::any::type_name::<Class>(),
+        );
+    };
+    let user_data = user_data.as_ref();
+    transmute::<&T, &'a T>(user_data)
+}
+
+#[inline]
+pub(crate) unsafe fn as_variant_ref<'a>(value: &'a *mut sys::godot_variant) -> &'a Variant {
+    // Trust Godot and will not check
+    NonNull::new_unchecked(*value).cast::<Variant>().as_ref()
+}
+
+#[inline]
+pub(crate) unsafe fn as_variant_args<'a>(
+    args: &'a *mut *mut sys::godot_variant,
+    num_args: c_int,
+) -> &'a [&'a Variant] {
+    // Trust Godot and will not check
+    std::slice::from_raw_parts(args.cast::<&Variant>(), num_args as usize)
+}
+
+pub(crate) struct FunctionWithSite<F: 'static + std::panic::RefUnwindSafe> {
+    pub site: crate::log::Site<'static>,
+    pub function: F,
+}
+
+impl<F: 'static + std::panic::RefUnwindSafe> FunctionWithSite<F> {
+    #[inline]
+    pub(crate) unsafe fn as_self<'a>(method_data: &'a *mut c_void) -> &'a Self {
+        // If the creation of method_data failed, then the method will not be registered
+        NonNull::new_unchecked(*method_data).cast().as_ref()
+    }
+}
+
+pub trait FromInstancePtr<'a>: Sized {
+    // The reason for no type constraints is to allow smart pointer replacement from external libraries
+    type RawBase;
+
+    unsafe fn from_instance_ptr<T>(user_data: &'a T, base: &'a *mut sys::godot_object) -> Self;
+}
+
+pub trait FromBasePtr<'a>: FromInstancePtr<'a> {
+    unsafe fn from_base_ptr(base_ptr: &'a *mut sys::godot_object) -> Self;
+}
+
+impl<'a, B: GodotObject> FromInstancePtr<'a> for Ref<B, Shared> {
+    type RawBase = B;
+
+    #[inline]
+    unsafe fn from_instance_ptr<T>(_user_data: &'a T, base: &'a *mut sys::godot_object) -> Self {
+        Self::from_base_ptr(base)
+    }
+}
+
+impl<'a, B: GodotObject> FromBasePtr<'a> for Ref<B, Shared> {
+    unsafe fn from_base_ptr(base: &'a *mut sys::godot_object) -> Self {
+        // Trust Godot and will not check
+        let base = NonNull::new_unchecked(*base);
+        Ref::from_sys(base)
+    }
+}
+
+impl<'a, B: GodotObject> FromInstancePtr<'a> for TRef<'a, B, Shared> {
+    type RawBase = B;
+
+    #[inline]
+    unsafe fn from_instance_ptr<T>(_user_data: &'a T, base: &'a *mut sys::godot_object) -> Self {
+        Self::from_base_ptr(base)
+    }
+}
+
+impl<'a, B: GodotObject> FromBasePtr<'a> for TRef<'a, B, Shared> {
+    unsafe fn from_base_ptr(base: &'a *mut sys::godot_object) -> Self {
+        // Trust Godot and will not check
+        let base = NonNull::new_unchecked(*base);
+        Ref::<B, Shared>::from_sys(base).assume_safe_unchecked()
+    }
+}
+
+impl<'a, B: GodotObject> FromInstancePtr<'a> for &'a B {
+    type RawBase = B;
+
+    #[inline]
+    unsafe fn from_instance_ptr<T>(_user_data: &'a T, base: &'a *mut sys::godot_object) -> Self {
+        Self::from_base_ptr(base)
+    }
+}
+
+impl<'a, B: GodotObject> FromBasePtr<'a> for &'a B {
+    unsafe fn from_base_ptr(base: &'a *mut sys::godot_object) -> Self {
+        // Trust Godot and will not check
+        let base = NonNull::new_unchecked(*base);
+        Ref::<B, Shared>::from_sys(base)
+            .assume_safe_unchecked()
+            .as_ref()
+    }
+}
+
+// TODO: FromInstancePtr for Instance
+// TODO: FromInstancePtr for TInstance

--- a/gdnative-core/src/register/method.rs
+++ b/gdnative-core/src/register/method.rs
@@ -1,0 +1,47 @@
+use std::{
+    ffi::{c_int, c_void},
+    panic::RefUnwindSafe,
+};
+
+use crate::core_types::Variant;
+
+use super::convert::{as_class, as_variant_args, FromInstancePtr, FunctionWithSite};
+
+// TODO: struct Method register
+
+unsafe extern "C" fn call_method<Class, F, AsClass, Base>(
+    base: *mut sys::godot_object,
+    method_data: *mut c_void,
+    user_data: *mut c_void,
+    num_args: c_int,
+    args: *mut *mut sys::godot_variant,
+) -> sys::godot_variant
+where
+    &'static Class: AsRef<AsClass> + 'static,
+    F: Fn(&AsClass, Base, &[&Variant]) -> Result<Variant, Box<dyn std::error::Error>>
+        + 'static
+        + RefUnwindSafe,
+    Base: for<'a> FromInstancePtr<'a>,
+{
+    let FunctionWithSite { site, function } = FunctionWithSite::<F>::as_self(&method_data);
+
+    std::panic::catch_unwind(move || {
+        crate::private::assert_main_thread();
+
+        let user_data = as_class::<Class, AsClass>(&user_data);
+        let base = Base::from_instance_ptr(user_data, &base);
+        let args = as_variant_args(&args, num_args);
+
+        function(user_data, base, args)
+    })
+    .unwrap_or_else(|e| {
+        crate::log::error(*site, "Method panicked");
+        crate::private::print_panic_error(e);
+        Ok(Variant::nil())
+    })
+    .unwrap_or_else(|e| {
+        crate::log::error(*site, format!("{e:?}"));
+        Variant::nil()
+    })
+    .leak()
+}

--- a/gdnative-core/src/register/mod.rs
+++ b/gdnative-core/src/register/mod.rs
@@ -1,0 +1,4 @@
+pub mod class;
+pub mod convert;
+pub mod method;
+pub mod property;

--- a/gdnative-core/src/register/property.rs
+++ b/gdnative-core/src/register/property.rs
@@ -1,0 +1,72 @@
+use std::{ffi::c_void, panic::RefUnwindSafe};
+
+use crate::core_types::Variant;
+
+use super::convert::{as_class, as_variant_ref, FromInstancePtr, FunctionWithSite};
+
+// TODO: struct Property register
+
+unsafe extern "C" fn call_setter<Class, F, AsClass, Base>(
+    base: *mut sys::godot_object,
+    method_data: *mut c_void,
+    user_data: *mut c_void,
+    value: *mut sys::godot_variant,
+) where
+    &'static Class: AsRef<AsClass> + 'static,
+    F: Fn(&AsClass, Base, &Variant) -> Result<(), Box<dyn std::error::Error>>
+        + 'static
+        + RefUnwindSafe,
+    Base: for<'a> FromInstancePtr<'a>,
+{
+    let FunctionWithSite { site, function } = FunctionWithSite::<F>::as_self(&method_data);
+
+    std::panic::catch_unwind(move || {
+        crate::private::assert_main_thread();
+
+        let user_data = as_class::<Class, AsClass>(&user_data);
+        let base = Base::from_instance_ptr(user_data, &base);
+        let value = as_variant_ref(&value);
+
+        function(user_data, base, value)
+    })
+    .unwrap_or_else(|e| {
+        crate::log::error(*site, "Setter panicked");
+        crate::private::print_panic_error(e);
+        Ok(())
+    })
+    .unwrap_or_else(|e| {
+        crate::log::error(*site, format!("{e:?}"));
+    });
+}
+
+unsafe extern "C" fn call_getter<Class, F, AsClass, Base>(
+    base: *mut sys::godot_object,
+    method_data: *mut c_void,
+    user_data: *mut c_void,
+) -> sys::godot_variant
+where
+    &'static Class: AsRef<AsClass> + 'static,
+    F: Fn(&AsClass, Base) -> Result<Variant, Box<dyn std::error::Error>> + 'static + RefUnwindSafe,
+    Base: for<'a> FromInstancePtr<'a>,
+{
+    let FunctionWithSite { site, function } = FunctionWithSite::<F>::as_self(&method_data);
+
+    std::panic::catch_unwind(move || {
+        crate::private::assert_main_thread();
+
+        let user_data = as_class::<Class, AsClass>(&user_data);
+        let base = Base::from_instance_ptr(user_data, &base);
+
+        function(user_data, base)
+    })
+    .unwrap_or_else(|e| {
+        crate::log::error(*site, "Getter panicked");
+        crate::private::print_panic_error(e);
+        Ok(Variant::nil())
+    })
+    .unwrap_or_else(|e| {
+        crate::log::error(*site, format!("{e:?}"));
+        Variant::nil()
+    })
+    .leak()
+}


### PR DESCRIPTION
It's been a while. Last time, tired of the language barrier, I disappeared. But I'll try again.

This is a proof of concept of the wrapper code used to register classes and methods with Godot.

## Design
**Update: Design intent was added.**

### Can register directly any type
Any type, such as `Rc<T>` or `rand::rngs::ThreadRng` (maybe even `Box<dyn T>`) can be register as class. Types are not required to implement the `NativeClass` trait.

Allowing `Rc<T>` to register directly will remove the boilerplate when shared values between Rust and Godot. Another goal is to remove restrictions on extension from external libraries.

**Boilerplate example: https://gist.github.com/B-head/21c659978ec55b6ae1b128db59f0d8e7**

### Flexible `self` and `#[base]` parameter type
If the registered class implements `AsRef<T>` trait, type `T` can be used for the `self` parameter of methods. `&Rc<Self>` or `&Arc<Self>` can also be used.

Types that implement `FromInstancePtr<'a>` trait and `FromBasePtr<'a>` trait can be used for `#[base]` parameter type. Smart pointers from external libraries can also be used if traits are implemented.

### Mutable references cannot be used for `self` parameter
Due to technical constraints because of use of `AsRef<T>` trait, mutable references cannot be used for `self` parameter. interior mutability must be introduced on the user side using `Cell<T>` or `RefCell<T>`.

Nevertheless, the code is better if interior mutability is introduced on the user side. Because:

- `Cell<T>`, `AtomicI32`, or other types can be used freely.
- By drop the reference guard before calling Godot method or before emit a signal, so that Rust method can be called again.

### Cannot be called from other than main thread
Instance creation and method calls are not allowed from threads created in Godot. Instead, create threads in Rust.

This is because they would not benefit from Rust static analysis. `Node` in Godot is not `Send` by Rust criteria because it is referenced by another `Node` without guard. However, Godot does not care about it but sends to other threads, so non `Send` values shared among threads are taken into Rust. And there is no way for Rust to detect that values are being shared among threads.

The same applies to calls to Rust methods after sharing values only between Godot threads, so do not create threads in Godot.

Incidentally, `call_deferred("emit_signal", ...)` can be used to safely send values from the thread created by Rust. (although marked as `unsafe` in the current API)

### zero overhead (Maybe)
Since Rust generates a type that uniquely identifies the function, so using generic parameters should result in zero overhead.

Reference: https://doc.rust-lang.org/std/primitive.fn.html#creating-function-pointers

## Additional suggestion
This could be a separate crate to support both gdnative and gdextension.