### PR TITLE
Implement support for flexible self types

### DIFF
--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -130,7 +130,7 @@ jobs:
           - rust: { toolchain: 'nightly' }
             testflags: '-- --skip ui_tests'
           - os: { id: ubuntu-latest, name: linux }
-            rust: { toolchain: '1.63', postfix: ' (msrv 1.63)' }
+            rust: { toolchain: '1.67', postfix: ' (msrv 1.67)' }
             testflags: '-- --skip ui_tests'
           - os: { id: ubuntu-latest, name: linux }
             rust: { toolchain: 'stable', postfix: ' (minimal-deps)', special: 'minimal-deps' }
@@ -298,16 +298,16 @@ jobs:
             godot: "3.5.1-stable"
             postfix: ' (nightly, inventory)'
             build_args: '--features inventory'
-          - rust: '1.63'
+          - rust: '1.67'
             godot: "3.5.1-stable"
-            postfix: ' (msrv 1.63)'
-          - rust: '1.63'
+            postfix: ' (msrv 1.67)'
+          - rust: '1.67'
             godot: "3.5.1-stable"
-            postfix: ' (msrv 1.63, ptrcall)'
+            postfix: ' (msrv 1.67, ptrcall)'
             build_args: '--features ptrcall'
-          - rust: '1.63'
+          - rust: '1.67'
             godot: "3.5.1-stable"
-            postfix: ' (msrv 1.63, inventory)'
+            postfix: ' (msrv 1.67, inventory)'
             build_args: '--features inventory'
 
           # Test with oldest supported engine version

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 The bindings cover most of the exposed API of Godot 3.5, and are being used on a number of projects in development, but we still expect non-trivial breaking changes in the API in the coming releases. godot-rust adheres to [Cargo's semantic versioning](https://doc.rust-lang.org/cargo/reference/semver.html).
 
-Minimum supported Rust version (MSRV) is **1.63**. We use the Rust 2021 Edition.
+Minimum supported Rust version (MSRV) is **1.67**. We use the Rust 2021 Edition.
 
 
 ## Engine compatibility

--- a/bindings-generator/Cargo.toml
+++ b/bindings-generator/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 version = "0.11.3"
 workspace = ".."
 edition = "2021"
-rust-version = "1.63"
+rust-version = "1.67"
 
 [features]
 debug = []

--- a/examples/builder-export/Cargo.toml
+++ b/examples/builder-export/Cargo.toml
@@ -3,7 +3,7 @@ name = "builder-export"
 version = "0.1.0"
 authors = ["The godot-rust developers"]
 edition = "2021"
-rust-version = "1.63"
+rust-version = "1.67"
 license = "MIT"
 publish = false
 

--- a/examples/dodge-the-creeps/Cargo.toml
+++ b/examples/dodge-the-creeps/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["The godot-rust developers"]
 publish = false
 edition = "2021"
-rust-version = "1.63"
+rust-version = "1.67"
 license = "MIT"
 
 [lib]

--- a/examples/godot_tps_controller_port/Cargo.toml
+++ b/examples/godot_tps_controller_port/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 authors = ["The godot-rust developers"]
 publish = false
-rust-version = "1.63"
+rust-version = "1.67"
 license = "MIT"
 
 [dependencies]

--- a/examples/hello-world/Cargo.toml
+++ b/examples/hello-world/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["The godot-rust developers"]
 publish = false
 edition = "2021"
-rust-version = "1.63"
+rust-version = "1.67"
 license = "MIT"
 
 [lib]

--- a/examples/native-plugin/Cargo.toml
+++ b/examples/native-plugin/Cargo.toml
@@ -3,7 +3,7 @@ name = "native-plugin"
 version = "0.1.0"
 authors = ["The godot-rust developers"]
 edition = "2021"
-rust-version = "1.63"
+rust-version = "1.67"
 license = "MIT"
 publish = false
 

--- a/examples/property-export/Cargo.toml
+++ b/examples/property-export/Cargo.toml
@@ -3,7 +3,7 @@ name = "property-export"
 version = "0.1.0"
 authors = ["The godot-rust developers"]
 edition = "2021"
-rust-version = "1.63"
+rust-version = "1.67"
 license = "MIT"
 publish = false
 

--- a/examples/resource/Cargo.toml
+++ b/examples/resource/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["The godot-rust developers"]
 publish = false
 edition = "2021"
-rust-version = "1.63"
+rust-version = "1.67"
 license = "MIT"
 
 [lib]

--- a/examples/rpc/Cargo.toml
+++ b/examples/rpc/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["The godot-rust developers"]
 publish = false
 edition = "2021"
-rust-version = "1.63"
+rust-version = "1.67"
 license = "MIT"
 
 [lib]

--- a/examples/scene-create/Cargo.toml
+++ b/examples/scene-create/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["The godot-rust developers"]
 publish = false
 edition = "2021"
-rust-version = "1.63"
+rust-version = "1.67"
 license = "MIT"
 
 [lib]

--- a/examples/signals/Cargo.toml
+++ b/examples/signals/Cargo.toml
@@ -3,7 +3,7 @@ name = "signals"
 version = "0.1.0"
 authors = ["The godot-rust developers"]
 edition = "2021"
-rust-version = "1.63"
+rust-version = "1.67"
 license = "MIT"
 publish = false
 

--- a/examples/spinning-cube/Cargo.toml
+++ b/examples/spinning-cube/Cargo.toml
@@ -3,7 +3,7 @@ name = "spinning-cube"
 version = "0.1.0"
 authors = ["The godot-rust developers"]
 edition = "2021"
-rust-version = "1.63"
+rust-version = "1.67"
 license = "MIT"
 publish = false
 

--- a/gdnative-async/Cargo.toml
+++ b/gdnative-async/Cargo.toml
@@ -9,7 +9,7 @@ version = "0.11.3"
 license = "MIT"
 workspace = ".."
 edition = "2021"
-rust-version = "1.63"
+rust-version = "1.67"
 
 [features]
 

--- a/gdnative-bindings/Cargo.toml
+++ b/gdnative-bindings/Cargo.toml
@@ -9,7 +9,7 @@ version = "0.11.3"
 license = "MIT"
 workspace = ".."
 edition = "2021"
-rust-version = "1.63"
+rust-version = "1.67"
 
 [features]
 formatted = []

--- a/gdnative-core/Cargo.toml
+++ b/gdnative-core/Cargo.toml
@@ -9,7 +9,7 @@ version = "0.11.3"
 license = "MIT"
 workspace = ".."
 edition = "2021"
-rust-version = "1.63"
+rust-version = "1.67"
 
 [features]
 default = []

--- a/gdnative-core/src/export/user_data.rs
+++ b/gdnative-core/src/export/user_data.rs
@@ -121,7 +121,7 @@ pub unsafe trait UserData: Sized + Clone {
 
 /// Trait for wrappers that can be mapped immutably.
 pub trait Map: UserData {
-    type Err: Debug;
+    type Err: std::error::Error;
 
     /// Maps a `&T` to `U`. Called for methods that take `&self`.
     ///
@@ -134,7 +134,7 @@ pub trait Map: UserData {
 
 /// Trait for wrappers that can be mapped mutably.
 pub trait MapMut: UserData {
-    type Err: Debug;
+    type Err: std::error::Error;
 
     /// Maps a `&mut T` to `U`. Called for methods that take `&mut self`.
     ///
@@ -147,7 +147,7 @@ pub trait MapMut: UserData {
 
 /// Trait for wrappers that can be mapped once.
 pub trait MapOwned: UserData {
-    type Err: Debug;
+    type Err: std::error::Error;
 
     /// Maps a `T` to `U`. Called for methods that take `self`. This method may fail with
     /// an error if it is called more than once on the same object.
@@ -168,10 +168,11 @@ pub type DefaultUserData<T> = LocalCellData<T>;
 #[allow(clippy::exhaustive_enums)] // explicitly uninhabited
 pub enum Infallible {}
 
+impl std::error::Error for Infallible {}
 impl std::fmt::Display for Infallible {
     #[inline]
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "operation that can't fail just failed")
+    fn fmt(&self, _f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        unreachable!("uninhabited enum")
     }
 }
 

--- a/gdnative-core/src/object/instance.rs
+++ b/gdnative-core/src/object/instance.rs
@@ -1,3 +1,4 @@
+use std::fmt::Debug;
 use std::ptr::NonNull;
 
 use crate::core_types::{
@@ -13,6 +14,9 @@ use crate::object::ownership::{NonUniqueOwnership, Ownership, Shared, ThreadLoca
 use crate::object::{GodotObject, Instanciable, QueueFree, RawObject, Ref, TRef};
 use crate::private::{get_api, ReferenceCountedClassPlaceholder};
 
+mod receiver;
+
+pub use receiver::Receiver;
 /// A persistent reference to a GodotObject with a rust NativeClass attached.
 ///
 /// `Instance`s can be worked on directly using `map` and `map_mut` if the base object is

--- a/gdnative-core/src/object/instance/receiver.rs
+++ b/gdnative-core/src/object/instance/receiver.rs
@@ -1,0 +1,133 @@
+use std::fmt::{Debug, Display};
+use std::sync::Arc;
+
+use crate::export::user_data::{ArcData, Map, MapMut, MapOwned};
+use crate::export::NativeClass;
+use crate::object::ownership::Shared;
+
+use super::{Instance, TInstance};
+
+/// Trait for types that can be used as the `self` or `#[self]` argument (receiver) for methods
+/// exported through the `#[methods]` attribute macro. This trait has no public interface, and
+/// is not intended to be implemented by users.
+///
+/// Notably, this is implemented for [`Instance`] and [`TInstance`] along with the usual `self`
+/// reference types. For types using [`ArcData`] as the wrapper specifically, [`Arc<C>`] is also
+/// allowed.
+///
+/// The trait is unsealed for technical coherence issues, but is not intended to be implemented
+/// by users. Changes to the definition of this trait are not considered breaking changes under
+/// semver.
+pub trait Receiver<C: NativeClass>: Sized {
+    #[doc(hidden)]
+    type This<'a>;
+    #[doc(hidden)]
+    type Err: Debug;
+
+    #[doc(hidden)]
+    fn with_instance<F, R>(instance: TInstance<'_, C, Shared>, f: F) -> Result<R, Self::Err>
+    where
+        F: for<'a> FnOnce(Self::This<'a>) -> R;
+}
+
+/// Error type indicating that an operation can't fail.
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+#[allow(clippy::exhaustive_enums)] // explicitly uninhabited
+pub enum Infallible {}
+
+impl Display for Infallible {
+    fn fmt(&self, _f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        unreachable!("uninhabited enum")
+    }
+}
+
+impl<'r, C: NativeClass> Receiver<C> for TInstance<'r, C, Shared> {
+    type This<'a> = TInstance<'a, C, Shared>;
+    type Err = Infallible;
+
+    #[inline]
+    fn with_instance<F, R>(instance: TInstance<'_, C, Shared>, f: F) -> Result<R, Self::Err>
+    where
+        F: for<'a> FnOnce(Self::This<'a>) -> R,
+    {
+        Ok(f(instance))
+    }
+}
+
+impl<C: NativeClass> Receiver<C> for Instance<C, Shared> {
+    type This<'a> = Instance<C, Shared>;
+    type Err = Infallible;
+
+    #[inline]
+    fn with_instance<F, R>(instance: TInstance<'_, C, Shared>, f: F) -> Result<R, Self::Err>
+    where
+        F: for<'a> FnOnce(Self::This<'a>) -> R,
+    {
+        Ok(f(instance.claim()))
+    }
+}
+
+impl<'r, C: NativeClass> Receiver<C> for &'r C
+where
+    C::UserData: Map,
+{
+    type This<'a> = &'a C;
+    type Err = <C::UserData as Map>::Err;
+
+    #[inline]
+    fn with_instance<F, R>(instance: TInstance<'_, C, Shared>, f: F) -> Result<R, Self::Err>
+    where
+        F: for<'a> FnOnce(Self::This<'a>) -> R,
+    {
+        instance.map(|this, _| f(this))
+    }
+}
+
+impl<'r, C: NativeClass> Receiver<C> for &'r mut C
+where
+    C::UserData: MapMut,
+{
+    type This<'a> = &'a mut C;
+    type Err = <C::UserData as MapMut>::Err;
+
+    #[inline]
+    fn with_instance<F, R>(instance: TInstance<'_, C, Shared>, f: F) -> Result<R, Self::Err>
+    where
+        F: for<'a> FnOnce(Self::This<'a>) -> R,
+    {
+        instance.map_mut(|this, _| f(this))
+    }
+}
+
+impl<C: NativeClass> Receiver<C> for C
+where
+    C::UserData: MapOwned,
+{
+    type This<'a> = C;
+    type Err = <C::UserData as MapOwned>::Err;
+
+    #[inline]
+    fn with_instance<F, R>(instance: TInstance<'_, C, Shared>, f: F) -> Result<R, Self::Err>
+    where
+        F: for<'a> FnOnce(Self::This<'a>) -> R,
+    {
+        instance.map_owned(|this, _| f(this))
+    }
+}
+
+impl<C> Receiver<C> for Arc<C>
+where
+    C: NativeClass<UserData = ArcData<C>>,
+{
+    type This<'a> = Arc<C>;
+    type Err = Infallible;
+
+    #[inline]
+    fn with_instance<F, R>(instance: TInstance<'_, C, Shared>, f: F) -> Result<R, Self::Err>
+    where
+        F: for<'a> FnOnce(Self::This<'a>) -> R,
+    {
+        let (_, script) = instance.claim().decouple();
+        Ok(f(script.into_inner()))
+    }
+}

--- a/gdnative-core/src/object/instance/receiver.rs
+++ b/gdnative-core/src/object/instance/receiver.rs
@@ -22,7 +22,7 @@ pub trait Receiver<C: NativeClass>: Sized {
     #[doc(hidden)]
     type This<'a>;
     #[doc(hidden)]
-    type Err: Debug;
+    type Err: std::error::Error;
 
     #[doc(hidden)]
     fn with_instance<F, R>(instance: TInstance<'_, C, Shared>, f: F) -> Result<R, Self::Err>
@@ -35,6 +35,7 @@ pub trait Receiver<C: NativeClass>: Sized {
 #[allow(clippy::exhaustive_enums)] // explicitly uninhabited
 pub enum Infallible {}
 
+impl std::error::Error for Infallible {}
 impl Display for Infallible {
     fn fmt(&self, _f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         unreachable!("uninhabited enum")

--- a/gdnative-derive/Cargo.toml
+++ b/gdnative-derive/Cargo.toml
@@ -9,7 +9,7 @@ version = "0.11.3"
 license = "MIT"
 workspace = ".."
 edition = "2021"
-rust-version = "1.63"
+rust-version = "1.67"
 
 [lib]
 proc-macro = true

--- a/gdnative-derive/src/lib.rs
+++ b/gdnative-derive/src/lib.rs
@@ -289,7 +289,13 @@ pub fn profiled(meta: TokenStream, input: TokenStream) -> TokenStream {
 /// [exporting](https://docs.godotengine.org/en/stable/tutorials/export/exporting_basics.html) in GDScript.
 ///
 /// A valid function signature must have:
-/// - `self`, `&self` or `&mut self` as its first parameter, if applicable.
+/// - Up to one receiver parameter as the first parameter. This can be one of:
+///     - `self`, `&self` or `&mut self`.
+///     - `self: Instance<Self>` or `self: TInstance<Self>`, when the `arbitrary_self_types` feature
+///       is available. Additionally, `self: Arc<Self>` is allowed when the `user_data` wrapper is
+///       specified to be `ArcData<Self>`.
+///     - `#[self] this: T` where `T` is any of the types mentioned above, as a workaround when
+///       `arbitrary_self_types` is unavailable.
 /// - Up of one of each of the following special arguments, in any order, denoted by the attributes:
 ///     - `#[base]` - A reference to the base/owner object. This may be `&T` or `TRef<T>`m where `T` refers to
 ///       the type declared in `#[inherit(T)]` attribute for the `NativeClass` type.
@@ -306,6 +312,10 @@ pub fn profiled(meta: TokenStream, input: TokenStream) -> TokenStream {
 /// // Associated function
 /// #[method]
 /// fn foo();
+///
+/// // Access `TInstance` instead of a variation of `self`, without `arbitrary_self_types`.
+/// #[method]
+/// fn foo(#[self] this: TInstance<Self>);
 ///
 /// // No access to base parameter
 /// #[method]

--- a/gdnative-derive/src/syntax/rpc_mode.rs
+++ b/gdnative-derive/src/syntax/rpc_mode.rs
@@ -1,7 +1,8 @@
 use quote::{quote, ToTokens};
 
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
 pub enum RpcMode {
+    #[default]
     Disabled,
     Remote,
     RemoteSync,
@@ -23,12 +24,6 @@ impl RpcMode {
             "puppet_sync" => Some(RpcMode::PuppetSync),
             _ => None,
         }
-    }
-}
-
-impl Default for RpcMode {
-    fn default() -> Self {
-        RpcMode::Disabled
     }
 }
 

--- a/gdnative-sys/Cargo.toml
+++ b/gdnative-sys/Cargo.toml
@@ -10,7 +10,7 @@ build = "build.rs"
 license = "MIT"
 workspace = ".."
 edition = "2021"
-rust-version = "1.63"
+rust-version = "1.67"
 
 [dependencies]
 libc = "0.2"

--- a/gdnative/Cargo.toml
+++ b/gdnative/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT"
 workspace = ".."
 readme = "../README.md"
 edition = "2021"
-rust-version = "1.63"
+rust-version = "1.67"
 
 [features]
 # Public

--- a/gdnative/tests/ui.rs
+++ b/gdnative/tests/ui.rs
@@ -3,9 +3,10 @@ fn ui_tests() {
     let t = trybuild::TestCases::new();
 
     // NativeClass
+    t.pass("tests/ui/derive_flexible_self_types.rs");
+    t.pass("tests/ui/derive_no_inherit.rs");
     t.pass("tests/ui/derive_pass.rs");
     t.pass("tests/ui/derive_property_basic.rs");
-    t.pass("tests/ui/derive_no_inherit.rs");
     t.compile_fail("tests/ui/derive_fail_inherit_param.rs");
     t.compile_fail("tests/ui/derive_fail_lifetime.rs");
     t.compile_fail("tests/ui/derive_fail_methods_list.rs");

--- a/gdnative/tests/ui/derive_flexible_self_types.rs
+++ b/gdnative/tests/ui/derive_flexible_self_types.rs
@@ -1,0 +1,28 @@
+use std::sync::Arc;
+
+use gdnative::prelude::*;
+
+#[derive(NativeClass)]
+#[user_data(gdnative::export::user_data::ArcData<Self>)]
+struct Foo {}
+
+#[methods]
+impl Foo {
+    fn new(_owner: &Reference) -> Self {
+        Foo {}
+    }
+
+    #[method]
+    fn none() {}
+
+    #[method]
+    fn arc(self: Arc<Self>) {}
+
+    #[method]
+    fn instance(#[self] this: Instance<Self>) {}
+
+    #[method]
+    fn t_instance(#[self] this: TInstance<Self>) {}
+}
+
+fn main() {}

--- a/impl/proc-macros/Cargo.toml
+++ b/impl/proc-macros/Cargo.toml
@@ -8,7 +8,7 @@ version = "0.11.3"
 license = "MIT"
 workspace = "../.."
 edition = "2021"
-rust-version = "1.63"
+rust-version = "1.67"
 
 [lib]
 proc-macro = true

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -3,7 +3,7 @@ name = "gdnative-test"
 version = "0.1.0"
 workspace = ".."
 edition = "2021"
-rust-version = "1.63"
+rust-version = "1.67"
 license = "MIT"
 publish = false
 


### PR DESCRIPTION
`Instance` and `TInstance` can now be used as self types where applicable. Additionally, `Arc` is supported when `ArcData` is used as the user-data wrapper.

The `self` type can be provided through the standard `arbitrary_self_types` syntax, or a `#[self]` attribute on the argument when unavailable.

This is technically a breaking change because all `UserData` errors are now required to implement `std::error::Error`, although the possibility of actual breakage should be pretty low -- the wrapper types we ship should be powerful enough to cover most if not all valid use cases.

Close #974