### PR TITLE
Enable the one-class-one-file feature by default for IDEs

### DIFF
--- a/gdnative-bindings/Cargo.toml
+++ b/gdnative-bindings/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2021"
 rust-version = "1.67"
 
 [features]
+default = ["one-class-one-file"]
 formatted = []
 one-class-one-file = []
 custom-godot = ["gdnative_bindings_generator/custom-godot"]


### PR DESCRIPTION
Improves IDE compatibility by default with minimal impact on build performance.

Close #1053