### PR TITLE
Add Flake for NixOS

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,46 @@
+{
+  description = "A gdnative project with nix";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    rust-overlay.url = "github:oxalica/rust-overlay";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, rust-overlay, flake-utils, ... }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        overlays = [
+          (import rust-overlay)
+
+        ];
+        pkgs = import nixpkgs {
+          inherit system overlays;
+        };
+      in
+      with pkgs;
+      {
+        devShells.default = mkShell.override { stdenv = pkgs.clangStdenv; } {
+          # Point bindgen to where the clang library would be
+          LIBCLANG_PATH = "${pkgs.libclang.lib}/lib";
+          # Make clang aware of a few headers (stdbool.h, wchar.h)
+          BINDGEN_EXTRA_CLANG_ARGS = with pkgs; ''
+            -isystem ${llvmPackages.libclang.lib}/lib/clang/${lib.getVersion clang}/include
+            -isystem ${llvmPackages.libclang.out}/lib/clang/${lib.getVersion clang}/include
+            -isystem ${glibc.dev}/include
+          '';
+
+          buildInputs = [
+            openssl
+            pkg-config
+            rust-bin.stable.latest.default
+            godot3
+          ];
+
+          shellHook = ''
+            alias godot="nixGL godot -e"
+          '';
+        };
+      }
+    );
+}


### PR DESCRIPTION
_Edit bromeon: copied description from https://github.com/godot-rust/gdnative/issues/1068_

# Case
So, after spending 4 whole days to make the bindgen and the gdnative work on my NixOs i came with a flake that i want to share.
i got fundamental help of my super NixOs-User  @storopoli.
## Flake
#https://github.com/jaoleal/Uni9Jogo/commit/3dcc053b103f4418c6d1365df6e7251edd203c98
Its not perfect and theres some diferences of the official one in the book
### Cons
 *  Does not have support for non-nixos nix environment since it does not include NixGL
### Pros
* Does not have NixGL
* Will not break with rust updates(the old one did)

Feel free to help improve it

