### PR TITLE
Suppress unused method warning when using custom-godot feature

### DIFF
--- a/gdnative-core/src/init/diagnostics/godot_version_mismatch.rs
+++ b/gdnative-core/src/init/diagnostics/godot_version_mismatch.rs
@@ -46,6 +46,7 @@ fn check_godot_version_mismatch() -> bool {
     }
 }
 
+#[allow(unused)]
 fn godot_version() -> Option<semver::Version> {
     let version = unsafe {
         let api = get_api();


### PR DESCRIPTION
When `custom-godot` feature is used during build, the following warning gets produced:
```
warning: function `godot_version` is never used
   |
50 | fn godot_version() -> Option<semver::Version> {
   |    ^^^^^^^^^^^^^
   |
```

This PR adds `#[allow(unused)]` directive to suppress this warning, since it becomes unused when `custom-godot` feature is enabled.